### PR TITLE
feat: add --summary flag to print run summary to stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ run:
 	  --mock.enabled=true \
 	  --mock.server.url=http://localhost:8080
 
+.PHONY: summary
+summary:
+	$(DIST_BIN) summary $(RESULTS_PATH)
+
 .PHONY: report
 report:
 	@echo "Viewing report..."

--- a/cmd/conformance/main_test.go
+++ b/cmd/conformance/main_test.go
@@ -63,7 +63,10 @@ func newRunCmd(m *testing.M) *cobra.Command {
 
 			// Run the test suites
 			code := m.Run()
-			maybeWriteSummary()
+			if err := maybeWriteSummary(); err != nil {
+				slog.Error("Failed to write summary", "error", err)
+				os.Exit(1)
+			}
 			os.Exit(code)
 
 			return nil

--- a/cmd/conformance/main_test.go
+++ b/cmd/conformance/main_test.go
@@ -63,6 +63,7 @@ func newRunCmd(m *testing.M) *cobra.Command {
 
 			// Run the test suites
 			code := m.Run()
+			maybeWriteSummary()
 			os.Exit(code)
 
 			return nil
@@ -126,6 +127,8 @@ func initCommands(m *testing.M) *cobra.Command {
 	runCmd.Flags().StringVar(&config.Parameters.ScenariosPublicIps, "scenarios.public.ips", "", "Scenario Public IPs Range")
 
 	runCmd.Flags().StringVar(&config.Parameters.ReportResultsPath, "report.results.path", "", "Report Results Path")
+	runCmd.Flags().StringVar(&config.Parameters.SummaryOutputPath, "output.summary.path", "", "Write JSON summary to this file after run")
+	runCmd.Flags().StringVar(&config.Parameters.SummaryFormat, "summary", "", "Print summary to stdout after run: json or text")
 
 	runCmd.Flags().BoolVar(&config.Parameters.MockEnabled, "mock.enabled", false, "Enable Mock Usage")
 	runCmd.Flags().StringVar(&config.Parameters.MockServerURL, "mock.server.url", "", "Mock Server URL")
@@ -149,6 +152,9 @@ func initCommands(m *testing.M) *cobra.Command {
 
 	listCmd := newListCmd()
 	rootCmd.AddCommand(listCmd)
+
+	summaryCmd := newSummaryCmd()
+	rootCmd.AddCommand(summaryCmd)
 
 	return rootCmd
 }

--- a/cmd/conformance/summary_cmd_test.go
+++ b/cmd/conformance/summary_cmd_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 
 	"github.com/eu-sovereign-cloud/conformance/internal/conformance/config"
@@ -36,30 +35,29 @@ func newSummaryCmd() *cobra.Command {
 	return cmd
 }
 
-func maybeWriteSummary() {
+func maybeWriteSummary() error {
 	needFile := config.Parameters.SummaryOutputPath != ""
 	needStdout := config.Parameters.SummaryFormat != ""
 	if !needFile && !needStdout {
-		return
+		return nil
 	}
 
 	s, err := report.BuildSummary(config.Parameters.ReportResultsPath)
 	if err != nil {
-		slog.Error("Failed to build summary", "error", err)
-		return
+		return fmt.Errorf("building summary: %w", err)
 	}
 
 	if needStdout {
 		switch config.Parameters.SummaryFormat {
 		case "text":
 			if err := report.WriteText(os.Stdout, s); err != nil {
-				slog.Error("Failed to write summary", "error", err)
+				return fmt.Errorf("writing text summary: %w", err)
 			}
 		default:
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			if err := enc.Encode(s); err != nil {
-				slog.Error("Failed to write summary", "error", err)
+				return fmt.Errorf("encoding json summary: %w", err)
 			}
 		}
 	}
@@ -67,11 +65,12 @@ func maybeWriteSummary() {
 	if needFile {
 		data, err := json.MarshalIndent(s, "", "  ")
 		if err != nil {
-			slog.Error("Failed to marshal summary", "error", err)
-			return
+			return fmt.Errorf("marshaling summary: %w", err)
 		}
-		if err := os.WriteFile(config.Parameters.SummaryOutputPath, data, 0o644); err != nil {
-			slog.Error("Failed to write summary file", "error", err)
+		if err := os.WriteFile(config.Parameters.SummaryOutputPath, data, 0o600); err != nil {
+			return fmt.Errorf("writing summary file: %w", err)
 		}
 	}
+
+	return nil
 }

--- a/cmd/conformance/summary_cmd_test.go
+++ b/cmd/conformance/summary_cmd_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/config"
+	"github.com/eu-sovereign-cloud/conformance/internal/report"
+	"github.com/spf13/cobra"
+)
+
+func newSummaryCmd() *cobra.Command {
+	var format string
+	cmd := &cobra.Command{
+		Use:   "summary <results-path>",
+		Short: "Print a structured summary of Allure result files",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			s, err := report.BuildSummary(args[0])
+			if err != nil {
+				return fmt.Errorf("building summary: %w", err)
+			}
+			switch format {
+			case "text":
+				return report.WriteText(os.Stdout, s)
+			default:
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(s)
+			}
+		},
+	}
+	cmd.Flags().StringVar(&format, "format", "json", "Output format: json or text")
+	return cmd
+}
+
+func maybeWriteSummary() {
+	needFile := config.Parameters.SummaryOutputPath != ""
+	needStdout := config.Parameters.SummaryFormat != ""
+	if !needFile && !needStdout {
+		return
+	}
+
+	s, err := report.BuildSummary(config.Parameters.ReportResultsPath)
+	if err != nil {
+		slog.Error("Failed to build summary", "error", err)
+		return
+	}
+
+	if needStdout {
+		switch config.Parameters.SummaryFormat {
+		case "text":
+			if err := report.WriteText(os.Stdout, s); err != nil {
+				slog.Error("Failed to write summary", "error", err)
+			}
+		default:
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(s); err != nil {
+				slog.Error("Failed to write summary", "error", err)
+			}
+		}
+	}
+
+	if needFile {
+		data, err := json.MarshalIndent(s, "", "  ")
+		if err != nil {
+			slog.Error("Failed to marshal summary", "error", err)
+			return
+		}
+		if err := os.WriteFile(config.Parameters.SummaryOutputPath, data, 0o644); err != nil {
+			slog.Error("Failed to write summary file", "error", err)
+		}
+	}
+}

--- a/internal/conformance/config/parameters.go
+++ b/internal/conformance/config/parameters.go
@@ -23,6 +23,8 @@ type ParametersHolder struct {
 	ScenariosPublicIps         string
 
 	ReportResultsPath string
+	SummaryOutputPath string
+	SummaryFormat     string
 
 	BaseDelay    int
 	BaseInterval int

--- a/internal/report/allure.go
+++ b/internal/report/allure.go
@@ -1,0 +1,25 @@
+package report
+
+type allureResult struct {
+	Name          string       `json:"name"`
+	FullName      string       `json:"fullName"`
+	Status        string       `json:"status"`
+	StatusDetails allureDetail `json:"statusDetails"`
+	Start         int64        `json:"start"`
+	Stop          int64        `json:"stop"`
+	Steps         []allureStep `json:"steps"`
+}
+
+type allureDetail struct {
+	Message string `json:"message"`
+	Trace   string `json:"trace"`
+}
+
+type allureStep struct {
+	Name          string       `json:"name"`
+	Status        string       `json:"status"`
+	StatusDetails allureDetail `json:"statusDetails"`
+	Start         int64        `json:"start"`
+	Stop          int64        `json:"stop"`
+	Steps         []allureStep `json:"steps"`
+}

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -45,15 +45,22 @@ type ErrorDetail struct {
 	Trace   string `json:"trace,omitempty"`
 }
 
+const (
+	statusFailed  = "failed"
+	statusBroken  = "broken"
+	statusPassed  = "passed"
+	statusSkipped = "skipped"
+)
+
 func statusPriority(status string) int {
 	switch status {
-	case "failed":
+	case statusFailed:
 		return 0
-	case "broken":
+	case statusBroken:
 		return 1
-	case "passed":
+	case statusPassed:
 		return 2
-	case "skipped":
+	case statusSkipped:
 		return 3
 	default:
 		return 4
@@ -66,7 +73,7 @@ func convertStep(s allureStep) StepResult {
 		Status:     s.Status,
 		DurationMs: s.Stop - s.Start,
 	}
-	if (s.Status == "failed" || s.Status == "broken") &&
+	if (s.Status == statusFailed || s.Status == statusBroken) &&
 		(s.StatusDetails.Message != "" || s.StatusDetails.Trace != "") {
 		sr.Error = &ErrorDetail{
 			Message: s.StatusDetails.Message,
@@ -105,13 +112,13 @@ func BuildSummary(resultsPath string) (*Summary, error) {
 
 		totals.Total++
 		switch ar.Status {
-		case "passed":
+		case statusPassed:
 			totals.Passed++
-		case "failed":
+		case statusFailed:
 			totals.Failed++
-		case "broken":
+		case statusBroken:
 			totals.Broken++
-		case "skipped":
+		case statusSkipped:
 			totals.Skipped++
 		}
 
@@ -121,7 +128,7 @@ func BuildSummary(resultsPath string) (*Summary, error) {
 			Status:     ar.Status,
 			DurationMs: ar.Stop - ar.Start,
 		}
-		if (ar.Status == "failed" || ar.Status == "broken") &&
+		if (ar.Status == statusFailed || ar.Status == statusBroken) &&
 			(ar.StatusDetails.Message != "" || ar.StatusDetails.Trace != "") {
 			sr.Error = &ErrorDetail{
 				Message: ar.StatusDetails.Message,

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -1,0 +1,151 @@
+package report
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Summary struct {
+	GeneratedAt time.Time        `json:"generated_at"`
+	Totals      Totals           `json:"totals"`
+	Scenarios   []ScenarioResult `json:"scenarios"`
+}
+
+type Totals struct {
+	Total   int `json:"total"`
+	Passed  int `json:"passed"`
+	Failed  int `json:"failed"`
+	Broken  int `json:"broken"`
+	Skipped int `json:"skipped"`
+}
+
+type ScenarioResult struct {
+	Name       string       `json:"name"`
+	FullName   string       `json:"full_name"`
+	Status     string       `json:"status"`
+	DurationMs int64        `json:"duration_ms"`
+	Error      *ErrorDetail `json:"error,omitempty"`
+	Steps      []StepResult `json:"steps,omitempty"`
+}
+
+type StepResult struct {
+	Name       string       `json:"name"`
+	Status     string       `json:"status"`
+	DurationMs int64        `json:"duration_ms"`
+	Error      *ErrorDetail `json:"error,omitempty"`
+	Steps      []StepResult `json:"steps,omitempty"`
+}
+
+type ErrorDetail struct {
+	Message string `json:"message,omitempty"`
+	Trace   string `json:"trace,omitempty"`
+}
+
+func statusPriority(status string) int {
+	switch status {
+	case "failed":
+		return 0
+	case "broken":
+		return 1
+	case "passed":
+		return 2
+	case "skipped":
+		return 3
+	default:
+		return 4
+	}
+}
+
+func convertStep(s allureStep) StepResult {
+	sr := StepResult{
+		Name:       s.Name,
+		Status:     s.Status,
+		DurationMs: s.Stop - s.Start,
+	}
+	if (s.Status == "failed" || s.Status == "broken") &&
+		(s.StatusDetails.Message != "" || s.StatusDetails.Trace != "") {
+		sr.Error = &ErrorDetail{
+			Message: s.StatusDetails.Message,
+			Trace:   s.StatusDetails.Trace,
+		}
+	}
+	for _, child := range s.Steps {
+		sr.Steps = append(sr.Steps, convertStep(child))
+	}
+	return sr
+}
+
+func BuildSummary(resultsPath string) (*Summary, error) {
+	entries, err := os.ReadDir(resultsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var scenarios []ScenarioResult
+	totals := Totals{}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "-result.json") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(resultsPath, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		var ar allureResult
+		if err := json.Unmarshal(data, &ar); err != nil {
+			return nil, err
+		}
+
+		totals.Total++
+		switch ar.Status {
+		case "passed":
+			totals.Passed++
+		case "failed":
+			totals.Failed++
+		case "broken":
+			totals.Broken++
+		case "skipped":
+			totals.Skipped++
+		}
+
+		sr := ScenarioResult{
+			Name:       ar.Name,
+			FullName:   ar.FullName,
+			Status:     ar.Status,
+			DurationMs: ar.Stop - ar.Start,
+		}
+		if (ar.Status == "failed" || ar.Status == "broken") &&
+			(ar.StatusDetails.Message != "" || ar.StatusDetails.Trace != "") {
+			sr.Error = &ErrorDetail{
+				Message: ar.StatusDetails.Message,
+				Trace:   ar.StatusDetails.Trace,
+			}
+		}
+		for _, step := range ar.Steps {
+			sr.Steps = append(sr.Steps, convertStep(step))
+		}
+
+		scenarios = append(scenarios, sr)
+	}
+
+	sort.Slice(scenarios, func(i, j int) bool {
+		pi, pj := statusPriority(scenarios[i].Status), statusPriority(scenarios[j].Status)
+		if pi != pj {
+			return pi < pj
+		}
+		return scenarios[i].Name < scenarios[j].Name
+	})
+
+	return &Summary{
+		GeneratedAt: time.Now().UTC(),
+		Totals:      totals,
+		Scenarios:   scenarios,
+	}, nil
+}

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -1,0 +1,63 @@
+package report
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+func WriteText(w io.Writer, s *Summary) error {
+	if _, err := fmt.Fprintf(w, "Conformance Summary — %s\n", s.GeneratedAt.Format("2006-01-02T15:04:05Z")); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "Total: %d  Passed: %d  Failed: %d  Broken: %d  Skipped: %d\n\n",
+		s.Totals.Total, s.Totals.Passed, s.Totals.Failed, s.Totals.Broken, s.Totals.Skipped); err != nil {
+		return err
+	}
+
+	for _, sc := range s.Scenarios {
+		if _, err := fmt.Fprintf(w, "%-8s %s  (%d ms)\n", strings.ToUpper(sc.Status), sc.FullName, sc.DurationMs); err != nil {
+			return err
+		}
+		if sc.Status != "passed" && sc.Status != "skipped" {
+			if sc.Error != nil && sc.Error.Message != "" {
+				if _, err := fmt.Fprintf(w, "  Error: %s\n", sc.Error.Message); err != nil {
+					return err
+				}
+			}
+			if len(sc.Steps) > 0 {
+				if _, err := fmt.Fprintln(w, "  Steps:"); err != nil {
+					return err
+				}
+				for _, step := range sc.Steps {
+					if err := writeStep(w, step, 2); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeStep(w io.Writer, step StepResult, depth int) error {
+	indent := strings.Repeat("  ", depth)
+	if _, err := fmt.Fprintf(w, "%s%-8s %s  (%d ms)\n", indent, strings.ToUpper(step.Status), step.Name, step.DurationMs); err != nil {
+		return err
+	}
+	if step.Error != nil && step.Error.Message != "" {
+		if _, err := fmt.Fprintf(w, "%s  Error: %s\n", indent, step.Error.Message); err != nil {
+			return err
+		}
+	}
+	for _, child := range step.Steps {
+		if err := writeStep(w, child, depth+1); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Add --summary text|json flag to the run command that prints a structured summary to stdout immediately after the test run completes.

- Add SummaryFormat field to ParametersHolder
- Register --summary flag on runCmd
- Refactor maybeWriteSummary to handle both stdout and file output, building the summary only once when both flags are set
- Add summary Makefile target for the summary subcommand