### PR TITLE
add 3 more usages scenario

### DIFF
--- a/cmd/conformance/usage_test.go
+++ b/cmd/conformance/usage_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestUsageV1Suites(t *testing.T) {
 	mixedTestSuite := suites.CreateMixedTestSuite(config.Parameters, config.Clients)
+	regionalTestSuite := suites.CreateRegionalTestSuite(config.Parameters, config.Clients)
 
 	// Foundation Providers Suite
 	foundationProvidersSuite := usage.CreateFoundationProvidersV1TestSuite(mixedTestSuite,
@@ -26,5 +27,47 @@ func TestUsageV1Suites(t *testing.T) {
 	)
 	if foundationProvidersSuite.CanRun(config.Parameters.ScenariosRegexp) {
 		suite.RunSuite(t, foundationProvidersSuite)
+	}
+
+	// Multi-Workspace Isolation Suite
+	multiWorkspaceIsolationSuite := usage.CreateMultiWorkspaceIsolationV1TestSuite(mixedTestSuite,
+		&usage.MultiWorkspaceIsolationV1Config{
+			Users:          config.Parameters.ScenariosUsers,
+			NetworkCidr:    config.Parameters.ScenariosCidr,
+			PublicIpsRange: config.Parameters.ScenariosPublicIps,
+			RegionZones:    config.Clients.RegionZones,
+			InstanceSkus:   config.Clients.InstanceSkus,
+			StorageSkus:    config.Clients.StorageSkus,
+			NetworkSkus:    config.Clients.NetworkSkus,
+		},
+	)
+	if multiWorkspaceIsolationSuite.CanRun(config.Parameters.ScenariosRegexp) {
+		suite.RunSuite(t, multiWorkspaceIsolationSuite)
+	}
+
+	// HA Multi-Zone Suite
+	haMultiZoneSuite := usage.CreateHaMultiZoneV1TestSuite(regionalTestSuite,
+		&usage.HaMultiZoneV1Config{
+			RegionZones:  config.Clients.RegionZones,
+			InstanceSkus: config.Clients.InstanceSkus,
+			StorageSkus:  config.Clients.StorageSkus,
+		},
+	)
+	if haMultiZoneSuite.CanRun(config.Parameters.ScenariosRegexp) {
+		suite.RunSuite(t, haMultiZoneSuite)
+	}
+
+	// Private Secure Workspace Suite
+	privateSecureWorkspaceSuite := usage.CreatePrivateSecureWorkspaceV1TestSuite(regionalTestSuite,
+		&usage.PrivateSecureWorkspaceV1Config{
+			NetworkCidr:  config.Parameters.ScenariosCidr,
+			RegionZones:  config.Clients.RegionZones,
+			InstanceSkus: config.Clients.InstanceSkus,
+			StorageSkus:  config.Clients.StorageSkus,
+			NetworkSkus:  config.Clients.NetworkSkus,
+		},
+	)
+	if privateSecureWorkspaceSuite.CanRun(config.Parameters.ScenariosRegexp) {
+		suite.RunSuite(t, privateSecureWorkspaceSuite)
 	}
 }

--- a/internal/conformance/params/params_v1.go
+++ b/internal/conformance/params/params_v1.go
@@ -307,6 +307,85 @@ type FoundationUsageV1Params struct {
 	Instance        *schema.Instance
 }
 
+// Usage - Multi-Tier Workload
+
+type MultiTierWorkloadV1Params struct {
+	Role           *schema.Role
+	RoleAssignment *schema.RoleAssignment
+	Workspace      *schema.Workspace
+
+	WebBootVolume  *schema.BlockStorage
+	DataBootVolume *schema.BlockStorage
+	DataVolume     *schema.BlockStorage
+
+	Network           *schema.Network
+	InternetGateway   *schema.InternetGateway
+	WebRouteTable     *schema.RouteTable
+	DataRouteTable    *schema.RouteTable
+	WebSubnet         *schema.Subnet
+	DataSubnet        *schema.Subnet
+	WebSecurityGroup  *schema.SecurityGroup
+	DataSecurityGroup *schema.SecurityGroup
+	PublicIp          *schema.PublicIp
+	WebNic            *schema.Nic
+	DataNic           *schema.Nic
+
+	WebInstance  *schema.Instance
+	DataInstance *schema.Instance
+}
+
+// Usage - Multi-Workspace Isolation
+
+type WorkspaceStackV1 struct {
+	BlockStorage    *schema.BlockStorage
+	Network         *schema.Network
+	InternetGateway *schema.InternetGateway
+	RouteTable      *schema.RouteTable
+	Subnet          *schema.Subnet
+	SecurityGroup   *schema.SecurityGroup
+	PublicIp        *schema.PublicIp
+	Nic             *schema.Nic
+	Instance        *schema.Instance
+	Instances       compute.InstanceIterator
+}
+
+type MultiWorkspaceIsolationV1Params struct {
+	Role           *schema.Role
+	RoleAssignment *schema.RoleAssignment
+
+	WorkspaceA *schema.Workspace
+	WorkspaceB *schema.Workspace
+
+	StackA WorkspaceStackV1
+	StackB WorkspaceStackV1
+}
+
+// Usage - HA Multi-Zone
+
+type HaMultiZoneV1Params struct {
+	Workspace *schema.Workspace
+
+	BlockStorageA *schema.BlockStorage
+	BlockStorageB *schema.BlockStorage
+
+	ReplicaA *schema.Instance
+	ReplicaB *schema.Instance
+}
+
+// Usage - Private Secure Workspace
+
+type PrivateSecureWorkspaceV1Params struct {
+	Workspace       *schema.Workspace
+	BlockStorage    *schema.BlockStorage
+	Network         *schema.Network
+	InternetGateway *schema.InternetGateway
+	RouteTable      *schema.RouteTable
+	Subnet          *schema.Subnet
+	SecurityGroup   *schema.SecurityGroup
+	Nic             *schema.Nic
+	Instance        *schema.Instance
+}
+
 // Network Constraints
 
 type NetworkConstraintsValidationV1Params struct {

--- a/internal/conformance/suites/usage/ha_multi_zone_v1.go
+++ b/internal/conformance/suites/usage/ha_multi_zone_v1.go
@@ -1,0 +1,344 @@
+package usage
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/params"
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/steps"
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/suites"
+	"github.com/eu-sovereign-cloud/conformance/internal/constants"
+	mockUsage "github.com/eu-sovereign-cloud/conformance/internal/mock/scenarios/usage"
+	"github.com/eu-sovereign-cloud/conformance/pkg/builders"
+	"github.com/eu-sovereign-cloud/conformance/pkg/generators"
+	sdkconsts "github.com/eu-sovereign-cloud/go-sdk/pkg/constants"
+	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/ozontech/allure-go/pkg/framework/provider"
+)
+
+// HaMultiZoneV1TestSuite provisions two replicas of the same service, tagged with the
+// same AntiAffinityGroup but placed in different zones, and starts both so they run
+// concurrently - the high-availability placement pattern where a provider is expected
+// to keep anti-affinity-grouped instances off the same underlying host.
+type HaMultiZoneV1TestSuite struct {
+	suites.RegionalTestSuite
+
+	config *HaMultiZoneV1Config
+	params *params.HaMultiZoneV1Params
+}
+
+type HaMultiZoneV1Config struct {
+	RegionZones  []string
+	StorageSkus  []string
+	InstanceSkus []string
+}
+
+func CreateHaMultiZoneV1TestSuite(regionalTestSuite suites.RegionalTestSuite, config *HaMultiZoneV1Config) *HaMultiZoneV1TestSuite {
+	suite := &HaMultiZoneV1TestSuite{
+		RegionalTestSuite: regionalTestSuite,
+		config:            config,
+	}
+	suite.ScenarioName = constants.UsageHaMultiZoneV1SuiteName.String()
+	return suite
+}
+
+func (suite *HaMultiZoneV1TestSuite) BeforeAll(t provider.T) {
+	t.AddParentSuite(suites.UsageParentSuite)
+
+	// Pick two distinct zones so the replicas land in different failure domains
+	zoneA := suite.config.RegionZones[rand.Intn(len(suite.config.RegionZones))]
+	zoneB := suite.config.RegionZones[(indexOf(suite.config.RegionZones, zoneA)+1)%len(suite.config.RegionZones)]
+
+	storageSkuName := suite.config.StorageSkus[rand.Intn(len(suite.config.StorageSkus))]
+	instanceSkuName := suite.config.InstanceSkus[rand.Intn(len(suite.config.InstanceSkus))]
+
+	antiAffinityGroup := fmt.Sprintf("ha-group-%d", rand.Intn(math.MaxInt32))
+
+	workspaceName := generators.GenerateWorkspaceName()
+
+	storageSkuRefObj := generators.GenerateSkuRefObject(sdkconsts.StorageProviderV1Name, suite.Tenant, storageSkuName)
+	instanceSkuRefObj := generators.GenerateSkuRefObject(sdkconsts.ComputeProviderV1Name, suite.Tenant, instanceSkuName)
+
+	blockStorageAName := generators.GenerateBlockStorageName()
+	blockStorageARefObj := generators.GenerateBlockStorageRefObject(sdkconsts.StorageProviderV1Name, suite.Tenant, workspaceName, blockStorageAName)
+
+	blockStorageBName := generators.GenerateBlockStorageName()
+	blockStorageBRefObj := generators.GenerateBlockStorageRefObject(sdkconsts.StorageProviderV1Name, suite.Tenant, workspaceName, blockStorageBName)
+
+	replicaAName := generators.GenerateInstanceName()
+	replicaBName := generators.GenerateInstanceName()
+
+	workspace, err := builders.NewWorkspaceBuilder().
+		Name(workspaceName).
+		Provider(sdkconsts.WorkspaceProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Region(suite.Region).
+		Labels(schema.Labels{
+			constants.EnvLabel: constants.EnvConformanceLabel,
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build Workspace: %v", err)
+	}
+
+	blockStorageA, err := builders.NewBlockStorageBuilder().
+		Name(blockStorageAName).
+		Provider(sdkconsts.StorageProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.BlockStorageSpec{
+			SkuRef: *storageSkuRefObj,
+			SizeGB: constants.BlockStorageInitialSize,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build BlockStorage A: %v", err)
+	}
+
+	blockStorageB, err := builders.NewBlockStorageBuilder().
+		Name(blockStorageBName).
+		Provider(sdkconsts.StorageProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.BlockStorageSpec{
+			SkuRef: *storageSkuRefObj,
+			SizeGB: constants.BlockStorageInitialSize,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build BlockStorage B: %v", err)
+	}
+
+	replicaA, err := builders.NewInstanceBuilder().
+		Name(replicaAName).
+		Provider(sdkconsts.ComputeProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Labels(schema.Labels{
+			constants.EnvLabel: constants.EnvConformanceLabel,
+		}).
+		Spec(&schema.InstanceSpec{
+			SkuRef:            *instanceSkuRefObj,
+			Zone:              zoneA,
+			AntiAffinityGroup: antiAffinityGroup,
+			BootVolume: schema.VolumeReference{
+				DeviceRef: *blockStorageARefObj,
+			},
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Replica A Instance: %v", err)
+	}
+
+	replicaB, err := builders.NewInstanceBuilder().
+		Name(replicaBName).
+		Provider(sdkconsts.ComputeProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Labels(schema.Labels{
+			constants.EnvLabel: constants.EnvConformanceLabel,
+		}).
+		Spec(&schema.InstanceSpec{
+			SkuRef:            *instanceSkuRefObj,
+			Zone:              zoneB,
+			AntiAffinityGroup: antiAffinityGroup,
+			BootVolume: schema.VolumeReference{
+				DeviceRef: *blockStorageBRefObj,
+			},
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Replica B Instance: %v", err)
+	}
+
+	p := &params.HaMultiZoneV1Params{
+		Workspace:     workspace,
+		BlockStorageA: blockStorageA,
+		BlockStorageB: blockStorageB,
+		ReplicaA:      replicaA,
+		ReplicaB:      replicaB,
+	}
+	suite.params = p
+	err = suites.SetupMockIfEnabled(suite.TestSuite, mockUsage.ConfigureHaMultiZoneV1, *p)
+	if err != nil {
+		t.Fatalf("Failed to setup mock: %v", err)
+	}
+}
+
+func (suite *HaMultiZoneV1TestSuite) TestScenario(t provider.T) {
+	suite.StartScenario(t,
+		sdkconsts.WorkspaceProviderV1Name,
+		sdkconsts.StorageProviderV1Name,
+		sdkconsts.ComputeProviderV1Name,
+	)
+	suite.ConfigureResources(t,
+		string(schema.RegionalResourceMetadataKindResourceKindWorkspace),
+		string(schema.RegionalResourceMetadataKindResourceKindBlockStorage),
+		string(schema.RegionalResourceMetadataKindResourceKindInstance),
+	)
+
+	stepsBuilder := steps.NewStepsConfigurator(suite.TestSuite, t)
+
+	workspace := suite.params.Workspace
+	expectWorkspaceMeta := workspace.Metadata
+	expectWorkspaceLabels := workspace.Labels
+	stepsBuilder.CreateOrUpdateWorkspaceV1Step("Create a workspace", t, suite.Client.WorkspaceV1, workspace,
+		steps.ResponseExpects[schema.RegionalResourceMetadata, schema.WorkspaceSpec]{
+			Labels:         expectWorkspaceLabels,
+			Metadata:       expectWorkspaceMeta,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetWorkspaceV1Step("Get the created workspace", suite.Client.WorkspaceV1,
+		secapi.TenantReference{Tenant: secapi.TenantID(workspace.Metadata.Tenant), Name: workspace.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalResourceMetadata, schema.WorkspaceSpec, schema.WorkspaceStatus]{
+			Labels:   expectWorkspaceLabels,
+			Metadata: expectWorkspaceMeta,
+			ResourceStatus: schema.WorkspaceStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	blockA := suite.params.BlockStorageA
+	expectBlockAMeta := blockA.Metadata
+	expectBlockASpec := &blockA.Spec
+	stepsBuilder.CreateOrUpdateBlockStorageV1Step("Create the replica A boot volume", t, suite.Client.StorageV1, blockA,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.BlockStorageSpec]{
+			Metadata:       expectBlockAMeta,
+			Spec:           expectBlockASpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetBlockStorageV1Step("Get the replica A boot volume", suite.Client.StorageV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(blockA.Metadata.Tenant), Workspace: secapi.WorkspaceID(blockA.Metadata.Workspace), Name: blockA.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.BlockStorageSpec, schema.BlockStorageStatus]{
+			Metadata: expectBlockAMeta,
+			Spec:     expectBlockASpec,
+			ResourceStatus: schema.BlockStorageStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	blockB := suite.params.BlockStorageB
+	expectBlockBMeta := blockB.Metadata
+	expectBlockBSpec := &blockB.Spec
+	stepsBuilder.CreateOrUpdateBlockStorageV1Step("Create the replica B boot volume", t, suite.Client.StorageV1, blockB,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.BlockStorageSpec]{
+			Metadata:       expectBlockBMeta,
+			Spec:           expectBlockBSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetBlockStorageV1Step("Get the replica B boot volume", suite.Client.StorageV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(blockB.Metadata.Tenant), Workspace: secapi.WorkspaceID(blockB.Metadata.Workspace), Name: blockB.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.BlockStorageSpec, schema.BlockStorageStatus]{
+			Metadata: expectBlockBMeta,
+			Spec:     expectBlockBSpec,
+			ResourceStatus: schema.BlockStorageStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	// Replica A - the response spec comparison round-trips both Zone and
+	// AntiAffinityGroup, proving the API accepts and persists the grouping.
+	replicaA := suite.params.ReplicaA
+	expectReplicaAMeta := replicaA.Metadata
+	expectReplicaASpec := &replicaA.Spec
+	stepsBuilder.CreateOrUpdateInstanceV1Step("Create replica A", t, suite.Client.ComputeV1, replicaA,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec]{
+			Metadata:       expectReplicaAMeta,
+			Spec:           expectReplicaASpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	replicaAWRef := secapi.WorkspaceReference{
+		Tenant:    secapi.TenantID(replicaA.Metadata.Tenant),
+		Workspace: secapi.WorkspaceID(replicaA.Metadata.Workspace),
+		Name:      replicaA.Metadata.Name,
+	}
+	replicaA = stepsBuilder.GetInstanceV1Step("Get replica A", suite.Client.ComputeV1, replicaAWRef,
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec, schema.InstanceStatus]{
+			Metadata: expectReplicaAMeta,
+			Spec:     expectReplicaASpec,
+			ResourceStatus: schema.InstanceStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	replicaB := suite.params.ReplicaB
+	expectReplicaBMeta := replicaB.Metadata
+	expectReplicaBSpec := &replicaB.Spec
+	stepsBuilder.CreateOrUpdateInstanceV1Step("Create replica B", t, suite.Client.ComputeV1, replicaB,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec]{
+			Metadata:       expectReplicaBMeta,
+			Spec:           expectReplicaBSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	replicaBWRef := secapi.WorkspaceReference{
+		Tenant:    secapi.TenantID(replicaB.Metadata.Tenant),
+		Workspace: secapi.WorkspaceID(replicaB.Metadata.Workspace),
+		Name:      replicaB.Metadata.Name,
+	}
+	replicaB = stepsBuilder.GetInstanceV1Step("Get replica B", suite.Client.ComputeV1, replicaBWRef,
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec, schema.InstanceStatus]{
+			Metadata: expectReplicaBMeta,
+			Spec:     expectReplicaBSpec,
+			ResourceStatus: schema.InstanceStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	// Bring both replicas up concurrently, as a real HA pair would run
+	stepsBuilder.StartInstanceV1Step("Start replica A", suite.Client.ComputeV1, replicaA)
+	replicaA = stepsBuilder.GetInstanceV1Step("Get the started replica A", suite.Client.ComputeV1, replicaAWRef,
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec, schema.InstanceStatus]{
+			Metadata: expectReplicaAMeta,
+			Spec:     expectReplicaASpec,
+			ResourceStatus: schema.InstanceStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterStartingWithoutUpdate,
+			},
+		},
+	)
+
+	stepsBuilder.StartInstanceV1Step("Start replica B", suite.Client.ComputeV1, replicaB)
+	replicaB = stepsBuilder.GetInstanceV1Step("Get the started replica B", suite.Client.ComputeV1, replicaBWRef,
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec, schema.InstanceStatus]{
+			Metadata: expectReplicaBMeta,
+			Spec:     expectReplicaBSpec,
+			ResourceStatus: schema.InstanceStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterStartingWithoutUpdate,
+			},
+		},
+	)
+
+	// Resources deletion
+	stepsBuilder.DeleteInstanceV1Step("Delete replica A", t, suite.Client.ComputeV1, replicaA)
+	stepsBuilder.DeleteInstanceV1Step("Delete replica B", t, suite.Client.ComputeV1, replicaB)
+
+	stepsBuilder.DeleteBlockStorageV1Step("Delete the replica A boot volume", t, suite.Client.StorageV1, blockA)
+	stepsBuilder.DeleteBlockStorageV1Step("Delete the replica B boot volume", t, suite.Client.StorageV1, blockB)
+
+	stepsBuilder.DeleteWorkspaceV1Step("Delete the workspace", t, suite.Client.WorkspaceV1, workspace)
+
+	suite.FinishScenario()
+}
+
+func (suite *HaMultiZoneV1TestSuite) AfterAll(t provider.T) {
+	suite.ResetAllScenarios()
+}
+
+func indexOf(items []string, target string) int {
+	for i, item := range items {
+		if item == target {
+			return i
+		}
+	}
+	return 0
+}

--- a/internal/conformance/suites/usage/multi_workspace_isolation_v1.go
+++ b/internal/conformance/suites/usage/multi_workspace_isolation_v1.go
@@ -1,0 +1,682 @@
+package usage
+
+import (
+	"log/slog"
+	"math/rand"
+	"net/http"
+
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/params"
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/steps"
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/suites"
+	"github.com/eu-sovereign-cloud/conformance/internal/constants"
+	mockUsage "github.com/eu-sovereign-cloud/conformance/internal/mock/scenarios/usage"
+	"github.com/eu-sovereign-cloud/conformance/pkg/builders"
+	"github.com/eu-sovereign-cloud/conformance/pkg/generators"
+	sdkconsts "github.com/eu-sovereign-cloud/go-sdk/pkg/constants"
+	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/ozontech/allure-go/pkg/framework/provider"
+)
+
+// MultiWorkspaceIsolationV1TestSuite provisions two fully independent regional resource
+// stacks (network, subnet, route table, gateway, security group, public IP, nic, block
+// storage, instance) in two separate workspaces of the same tenant, all governed by a
+// single Role/RoleAssignment scoped to both workspace names. It verifies that the shared
+// RBAC grant works across both workspaces, and that listing instances per workspace
+// only ever returns that workspace's own resources (isolation).
+type MultiWorkspaceIsolationV1TestSuite struct {
+	suites.MixedTestSuite
+
+	config *MultiWorkspaceIsolationV1Config
+	params *params.MultiWorkspaceIsolationV1Params
+}
+
+type MultiWorkspaceIsolationV1Config struct {
+	Users          []string
+	NetworkCidr    string
+	PublicIpsRange string
+	RegionZones    []string
+	StorageSkus    []string
+	InstanceSkus   []string
+	NetworkSkus    []string
+}
+
+func CreateMultiWorkspaceIsolationV1TestSuite(mixedTestSuite suites.MixedTestSuite, config *MultiWorkspaceIsolationV1Config) *MultiWorkspaceIsolationV1TestSuite {
+	suite := &MultiWorkspaceIsolationV1TestSuite{
+		MixedTestSuite: mixedTestSuite,
+		config:         config,
+	}
+	suite.ScenarioName = constants.UsageMultiWorkspaceIsolationV1SuiteName.String()
+	return suite
+}
+
+// buildWorkspaceStack builds one fully independent regional resource stack (network
+// topology + storage + a single instance) for the given workspace, using netNum to
+// derive a non-overlapping subnet and public IP from the shared scenario ranges.
+func (suite *MultiWorkspaceIsolationV1TestSuite) buildWorkspaceStack(t provider.T, workspaceName string, netNum int) params.WorkspaceStackV1 {
+	zone := suite.config.RegionZones[rand.Intn(len(suite.config.RegionZones))]
+	storageSkuName := suite.config.StorageSkus[rand.Intn(len(suite.config.StorageSkus))]
+	instanceSkuName := suite.config.InstanceSkus[rand.Intn(len(suite.config.InstanceSkus))]
+	networkSkuName := suite.config.NetworkSkus[rand.Intn(len(suite.config.NetworkSkus))]
+
+	subnetCidr, err := generators.GenerateSubnetCidr(suite.config.NetworkCidr, 8, netNum)
+	if err != nil {
+		slog.Error("Failed to generate subnet cidr", "error", err)
+		t.FailNow()
+	}
+	nicAddress, err := generators.GenerateNicAddress(subnetCidr, 1)
+	if err != nil {
+		slog.Error("Failed to generate nic address", "error", err)
+		t.FailNow()
+	}
+	publicIpAddress, err := generators.GeneratePublicIp(suite.config.PublicIpsRange, netNum)
+	if err != nil {
+		slog.Error("Failed to generate public ip", "error", err)
+		t.FailNow()
+	}
+
+	storageSkuRefObj := generators.GenerateSkuRefObject(sdkconsts.StorageProviderV1Name, suite.Tenant, storageSkuName)
+	instanceSkuRefObj := generators.GenerateSkuRefObject(sdkconsts.ComputeProviderV1Name, suite.Tenant, instanceSkuName)
+	networkSkuRefObj := generators.GenerateSkuRefObject(sdkconsts.NetworkProviderV1Name, suite.Tenant, networkSkuName)
+
+	blockStorageName := generators.GenerateBlockStorageName()
+	blockStorageRefObj := generators.GenerateBlockStorageRefObject(sdkconsts.StorageProviderV1Name, suite.Tenant, workspaceName, blockStorageName)
+
+	networkName := generators.GenerateNetworkName()
+
+	internetGatewayName := generators.GenerateInternetGatewayName()
+	internetGatewayRefObj := generators.GenerateInternetGatewayRefObject(sdkconsts.NetworkProviderV1Name, suite.Tenant, workspaceName, internetGatewayName)
+
+	routeTableName := generators.GenerateRouteTableName()
+	routeTableRefObj := generators.GenerateRouteTableRefObject(sdkconsts.NetworkProviderV1Name, suite.Tenant, workspaceName, networkName, routeTableName)
+
+	subnetName := generators.GenerateSubnetName()
+	subnetRefObj := generators.GenerateSubnetRefObject(sdkconsts.NetworkProviderV1Name, suite.Tenant, workspaceName, networkName, subnetName)
+
+	securityGroupName := generators.GenerateSecurityGroupName()
+
+	publicIpName := generators.GeneratePublicIpName()
+	publicIpRefObj := generators.GeneratePublicIpRefObject(sdkconsts.NetworkProviderV1Name, suite.Tenant, workspaceName, publicIpName)
+
+	nicName := generators.GenerateNicName()
+
+	instanceName := generators.GenerateInstanceName()
+
+	blockStorage, err := builders.NewBlockStorageBuilder().
+		Name(blockStorageName).
+		Provider(sdkconsts.StorageProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.BlockStorageSpec{
+			SkuRef: *storageSkuRefObj,
+			SizeGB: constants.BlockStorageInitialSize,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build BlockStorage: %v", err)
+	}
+
+	network, err := builders.NewNetworkBuilder().
+		Name(networkName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.NetworkSpec{
+			Cidr:   schema.Cidr{Ipv4: suite.config.NetworkCidr},
+			SkuRef: *networkSkuRefObj,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Network: %v", err)
+	}
+
+	internetGateway, err := builders.NewInternetGatewayBuilder().
+		Name(internetGatewayName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.InternetGatewaySpec{
+			EgressOnly: false,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Internet Gateway: %v", err)
+	}
+
+	routeTable, err := builders.NewRouteTableBuilder().
+		Name(routeTableName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).Network(networkName).
+		Spec(&schema.RouteTableSpec{
+			Routes: []schema.RouteSpec{
+				{DestinationCidrBlock: constants.RouteTableDefaultDestination, TargetRef: *internetGatewayRefObj},
+			},
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Route Table: %v", err)
+	}
+
+	subnet, err := builders.NewSubnetBuilder().
+		Name(subnetName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).Network(networkName).
+		Spec(&schema.SubnetSpec{
+			Cidr:          schema.Cidr{Ipv4: subnetCidr},
+			RouteTableRef: *routeTableRefObj,
+			Zone:          zone,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Subnet: %v", err)
+	}
+
+	securityGroup, err := builders.NewSecurityGroupBuilder().
+		Name(securityGroupName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.SecurityGroupSpec{
+			Rules: []schema.SecurityGroupRuleSpec{{Direction: schema.SecurityGroupRuleDirectionIngress}},
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Security Group: %v", err)
+	}
+
+	publicIp, err := builders.NewPublicIpBuilder().
+		Name(publicIpName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.PublicIpSpec{
+			Version: schema.IPVersionIPv4,
+			Address: publicIpAddress,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Public IP: %v", err)
+	}
+
+	nic, err := builders.NewNicBuilder().
+		Name(nicName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.NicSpec{
+			Addresses:    []string{nicAddress},
+			PublicIpRefs: []schema.Reference{*publicIpRefObj},
+			SubnetRef:    *subnetRefObj,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Nic: %v", err)
+	}
+
+	instance, err := builders.NewInstanceBuilder().
+		Name(instanceName).
+		Provider(sdkconsts.ComputeProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.InstanceSpec{
+			SkuRef: *instanceSkuRefObj,
+			Zone:   zone,
+			BootVolume: schema.VolumeReference{
+				DeviceRef: *blockStorageRefObj,
+			},
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Instance: %v", err)
+	}
+
+	instanceIterator, err := builders.NewInstanceIteratorBuilder().
+		Provider(sdkconsts.ComputeProviderV1Name).
+		Tenant(suite.Tenant).Workspace(workspaceName).
+		Items([]schema.Instance{*instance}).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build InstanceIterator: %v", err)
+	}
+
+	return params.WorkspaceStackV1{
+		BlockStorage:    blockStorage,
+		Network:         network,
+		InternetGateway: internetGateway,
+		RouteTable:      routeTable,
+		Subnet:          subnet,
+		SecurityGroup:   securityGroup,
+		PublicIp:        publicIp,
+		Nic:             nic,
+		Instance:        instance,
+		Instances:       *instanceIterator,
+	}
+}
+
+func (suite *MultiWorkspaceIsolationV1TestSuite) BeforeAll(t provider.T) {
+	t.AddParentSuite(suites.UsageParentSuite)
+
+	roleAssignmentSub := suite.config.Users[rand.Intn(len(suite.config.Users))]
+
+	workspaceAName := generators.GenerateWorkspaceName()
+	workspaceBName := generators.GenerateWorkspaceName()
+
+	roleName := generators.GenerateRoleName()
+	roleAssignmentName := generators.GenerateRoleAssignmentName()
+
+	// RBAC: a single grant scoped to both workspaces, read-only across every resource
+	// kind used by the two independent stacks.
+	role, err := builders.NewRoleBuilder().
+		Name(roleName).
+		Provider(sdkconsts.AuthorizationProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).
+		Spec(&schema.RoleSpec{
+			Permissions: []schema.Permission{
+				{Provider: sdkconsts.WorkspaceProviderV1Name, Resources: []string{generators.GenerateWorkspaceListResource()}, Verb: []string{http.MethodGet}},
+				{Provider: sdkconsts.NetworkProviderV1Name, Resources: []string{generators.GenerateNetworkListResource()}, Verb: []string{http.MethodGet}},
+				{Provider: sdkconsts.ComputeProviderV1Name, Resources: []string{generators.GenerateInstanceListResource()}, Verb: []string{http.MethodGet}},
+				{Provider: sdkconsts.StorageProviderV1Name, Resources: []string{generators.GenerateBlockStorageListResource()}, Verb: []string{http.MethodGet}},
+			},
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build Role: %v", err)
+	}
+
+	roleAssignment, err := builders.NewRoleAssignmentBuilder().
+		Name(roleAssignmentName).
+		Provider(sdkconsts.AuthorizationProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).
+		Spec(&schema.RoleAssignmentSpec{
+			Roles: []string{roleName},
+			Subs:  []string{roleAssignmentSub},
+			Scopes: []schema.RoleAssignmentScope{
+				{Workspaces: []string{workspaceAName, workspaceBName}},
+			},
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build RoleAssignment: %v", err)
+	}
+
+	workspaceA, err := builders.NewWorkspaceBuilder().
+		Name(workspaceAName).
+		Provider(sdkconsts.WorkspaceProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Region(suite.Region).
+		Labels(schema.Labels{
+			constants.EnvLabel: constants.EnvConformanceLabel,
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build Workspace A: %v", err)
+	}
+
+	workspaceB, err := builders.NewWorkspaceBuilder().
+		Name(workspaceBName).
+		Provider(sdkconsts.WorkspaceProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Region(suite.Region).
+		Labels(schema.Labels{
+			constants.EnvLabel: constants.EnvConformanceLabel,
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build Workspace B: %v", err)
+	}
+
+	stackA := suite.buildWorkspaceStack(t, workspaceAName, 1)
+	stackB := suite.buildWorkspaceStack(t, workspaceBName, 2)
+
+	p := &params.MultiWorkspaceIsolationV1Params{
+		Role:           role,
+		RoleAssignment: roleAssignment,
+		WorkspaceA:     workspaceA,
+		WorkspaceB:     workspaceB,
+		StackA:         stackA,
+		StackB:         stackB,
+	}
+	suite.params = p
+	err = suites.SetupMockIfEnabled(suite.TestSuite, mockUsage.ConfigureMultiWorkspaceIsolationV1, *p)
+	if err != nil {
+		t.Fatalf("Failed to setup mock: %v", err)
+	}
+}
+
+// createStack runs the create+get steps for one workspace's full resource stack and
+// returns the observed instance, so it can be used for the isolation List check.
+func (suite *MultiWorkspaceIsolationV1TestSuite) createStack(t provider.T, stepsBuilder *steps.StepsConfigurator, label string, workspace *schema.Workspace, stack params.WorkspaceStackV1) *schema.Instance {
+	expectWorkspaceMeta := workspace.Metadata
+	expectWorkspaceLabels := workspace.Labels
+	stepsBuilder.CreateOrUpdateWorkspaceV1Step("Create workspace "+label, t, suite.RegionalClient.WorkspaceV1, workspace,
+		steps.ResponseExpects[schema.RegionalResourceMetadata, schema.WorkspaceSpec]{
+			Labels:         expectWorkspaceLabels,
+			Metadata:       expectWorkspaceMeta,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetWorkspaceV1Step("Get workspace "+label, suite.RegionalClient.WorkspaceV1,
+		secapi.TenantReference{Tenant: secapi.TenantID(workspace.Metadata.Tenant), Name: workspace.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalResourceMetadata, schema.WorkspaceSpec, schema.WorkspaceStatus]{
+			Labels:   expectWorkspaceLabels,
+			Metadata: expectWorkspaceMeta,
+			ResourceStatus: schema.WorkspaceStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	block := stack.BlockStorage
+	expectBlockMeta := block.Metadata
+	expectBlockSpec := &block.Spec
+	stepsBuilder.CreateOrUpdateBlockStorageV1Step("Create block storage "+label, t, suite.RegionalClient.StorageV1, block,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.BlockStorageSpec]{
+			Metadata:       expectBlockMeta,
+			Spec:           expectBlockSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetBlockStorageV1Step("Get block storage "+label, suite.RegionalClient.StorageV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(block.Metadata.Tenant), Workspace: secapi.WorkspaceID(block.Metadata.Workspace), Name: block.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.BlockStorageSpec, schema.BlockStorageStatus]{
+			Metadata: expectBlockMeta,
+			Spec:     expectBlockSpec,
+			ResourceStatus: schema.BlockStorageStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	network := stack.Network
+	expectNetworkMeta := network.Metadata
+	expectNetworkSpec := &network.Spec
+	stepsBuilder.CreateOrUpdateNetworkV1Step("Create network "+label, t, suite.RegionalClient.NetworkV1, network,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.NetworkSpec]{
+			Metadata:       expectNetworkMeta,
+			Spec:           expectNetworkSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+
+	gateway := stack.InternetGateway
+	expectGatewayMeta := gateway.Metadata
+	expectGatewaySpec := &gateway.Spec
+	stepsBuilder.CreateOrUpdateInternetGatewayV1Step("Create internet gateway "+label, t, suite.RegionalClient.NetworkV1, gateway,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.InternetGatewaySpec]{
+			Metadata:       expectGatewayMeta,
+			Spec:           expectGatewaySpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetInternetGatewayV1Step("Get internet gateway "+label, suite.RegionalClient.NetworkV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(gateway.Metadata.Tenant), Workspace: secapi.WorkspaceID(gateway.Metadata.Workspace), Name: gateway.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.InternetGatewaySpec, schema.InternetGatewayStatus]{
+			Metadata: expectGatewayMeta,
+			Spec:     expectGatewaySpec,
+			ResourceStatus: schema.InternetGatewayStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	route := stack.RouteTable
+	expectRouteMeta := route.Metadata
+	expectRouteSpec := &route.Spec
+	stepsBuilder.CreateOrUpdateRouteTableV1Step("Create route table "+label, t, suite.RegionalClient.NetworkV1, route,
+		steps.ResponseExpects[schema.RegionalNetworkResourceMetadata, schema.RouteTableSpec]{
+			Metadata:       expectRouteMeta,
+			Spec:           expectRouteSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetRouteTableV1Step("Get route table "+label, suite.RegionalClient.NetworkV1,
+		secapi.NetworkReference{Tenant: secapi.TenantID(route.Metadata.Tenant), Workspace: secapi.WorkspaceID(route.Metadata.Workspace), Network: secapi.NetworkID(route.Metadata.Network), Name: route.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalNetworkResourceMetadata, schema.RouteTableSpec, schema.RouteTableStatus]{
+			Metadata: expectRouteMeta,
+			Spec:     expectRouteSpec,
+			ResourceStatus: schema.RouteTableStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	stepsBuilder.GetNetworkV1Step("Get network "+label, suite.RegionalClient.NetworkV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(network.Metadata.Tenant), Workspace: secapi.WorkspaceID(network.Metadata.Workspace), Name: network.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.NetworkSpec, schema.NetworkStatus]{
+			Metadata: expectNetworkMeta,
+			Spec:     expectNetworkSpec,
+			ResourceStatus: schema.NetworkStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	subnet := stack.Subnet
+	expectSubnetMeta := subnet.Metadata
+	expectSubnetSpec := &subnet.Spec
+	stepsBuilder.CreateOrUpdateSubnetV1Step("Create subnet "+label, t, suite.RegionalClient.NetworkV1, subnet,
+		steps.ResponseExpects[schema.RegionalNetworkResourceMetadata, schema.SubnetSpec]{
+			Metadata:       expectSubnetMeta,
+			Spec:           expectSubnetSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetSubnetV1Step("Get subnet "+label, suite.RegionalClient.NetworkV1,
+		secapi.NetworkReference{Tenant: secapi.TenantID(subnet.Metadata.Tenant), Workspace: secapi.WorkspaceID(subnet.Metadata.Workspace), Network: secapi.NetworkID(subnet.Metadata.Network), Name: subnet.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalNetworkResourceMetadata, schema.SubnetSpec, schema.SubnetStatus]{
+			Metadata: expectSubnetMeta,
+			Spec:     expectSubnetSpec,
+			ResourceStatus: schema.SubnetStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	group := stack.SecurityGroup
+	expectGroupMeta := group.Metadata
+	expectGroupSpec := &group.Spec
+	stepsBuilder.CreateOrUpdateSecurityGroupV1Step("Create security group "+label, t, suite.RegionalClient.NetworkV1, group,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.SecurityGroupSpec]{
+			Metadata:       expectGroupMeta,
+			Spec:           expectGroupSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetSecurityGroupV1Step("Get security group "+label, suite.RegionalClient.NetworkV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(group.Metadata.Tenant), Workspace: secapi.WorkspaceID(group.Metadata.Workspace), Name: group.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.SecurityGroupSpec, schema.SecurityGroupStatus]{
+			Metadata: expectGroupMeta,
+			Spec:     expectGroupSpec,
+			ResourceStatus: schema.SecurityGroupStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	publicIp := stack.PublicIp
+	expectPublicIpMeta := publicIp.Metadata
+	expectPublicIpSpec := &publicIp.Spec
+	stepsBuilder.CreateOrUpdatePublicIpV1Step("Create public ip "+label, t, suite.RegionalClient.NetworkV1, publicIp,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.PublicIpSpec]{
+			Metadata:       expectPublicIpMeta,
+			Spec:           expectPublicIpSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetPublicIpV1Step("Get public ip "+label, suite.RegionalClient.NetworkV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(publicIp.Metadata.Tenant), Workspace: secapi.WorkspaceID(publicIp.Metadata.Workspace), Name: publicIp.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.PublicIpSpec, schema.PublicIpStatus]{
+			Metadata: expectPublicIpMeta,
+			Spec:     expectPublicIpSpec,
+			ResourceStatus: schema.PublicIpStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	nic := stack.Nic
+	expectNicMeta := nic.Metadata
+	expectNicSpec := &nic.Spec
+	stepsBuilder.CreateOrUpdateNicV1Step("Create nic "+label, t, suite.RegionalClient.NetworkV1, nic,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.NicSpec]{
+			Metadata:       expectNicMeta,
+			Spec:           expectNicSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetNicV1Step("Get nic "+label, suite.RegionalClient.NetworkV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(nic.Metadata.Tenant), Workspace: secapi.WorkspaceID(nic.Metadata.Workspace), Name: nic.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.NicSpec, schema.NicStatus]{
+			Metadata: expectNicMeta,
+			Spec:     expectNicSpec,
+			ResourceStatus: schema.NicStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	instance := stack.Instance
+	expectInstanceMeta := instance.Metadata
+	expectInstanceSpec := &instance.Spec
+	stepsBuilder.CreateOrUpdateInstanceV1Step("Create instance "+label, t, suite.RegionalClient.ComputeV1, instance,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec]{
+			Metadata:       expectInstanceMeta,
+			Spec:           expectInstanceSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	instance = stepsBuilder.GetInstanceV1Step("Get instance "+label, suite.RegionalClient.ComputeV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(instance.Metadata.Tenant), Workspace: secapi.WorkspaceID(instance.Metadata.Workspace), Name: instance.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec, schema.InstanceStatus]{
+			Metadata: expectInstanceMeta,
+			Spec:     expectInstanceSpec,
+			ResourceStatus: schema.InstanceStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	return instance
+}
+
+// deleteStack runs the deletion steps for one workspace's full resource stack in
+// reverse dependency order. stack.Instance must hold the observed instance (the
+// value returned by createStack), not the pre-create fixture.
+func (suite *MultiWorkspaceIsolationV1TestSuite) deleteStack(t provider.T, stepsBuilder *steps.StepsConfigurator, label string, workspace *schema.Workspace, stack params.WorkspaceStackV1) {
+	stepsBuilder.DeleteInstanceV1Step("Delete instance "+label, t, suite.RegionalClient.ComputeV1, stack.Instance)
+	stepsBuilder.DeleteNicV1Step("Delete nic "+label, t, suite.RegionalClient.NetworkV1, stack.Nic)
+	stepsBuilder.DeletePublicIpV1Step("Delete public ip "+label, t, suite.RegionalClient.NetworkV1, stack.PublicIp)
+	stepsBuilder.DeleteSecurityGroupV1Step("Delete security group "+label, t, suite.RegionalClient.NetworkV1, stack.SecurityGroup)
+	stepsBuilder.DeleteSubnetV1Step("Delete subnet "+label, t, suite.RegionalClient.NetworkV1, stack.Subnet)
+	stepsBuilder.DeleteRouteTableV1Step("Delete route table "+label, t, suite.RegionalClient.NetworkV1, stack.RouteTable)
+	stepsBuilder.DeleteInternetGatewayV1Step("Delete internet gateway "+label, t, suite.RegionalClient.NetworkV1, stack.InternetGateway)
+	stepsBuilder.DeleteNetworkV1Step("Delete network "+label, t, suite.RegionalClient.NetworkV1, stack.Network)
+	stepsBuilder.DeleteBlockStorageV1Step("Delete block storage "+label, t, suite.RegionalClient.StorageV1, stack.BlockStorage)
+	stepsBuilder.DeleteWorkspaceV1Step("Delete workspace "+label, t, suite.RegionalClient.WorkspaceV1, workspace)
+}
+
+func (suite *MultiWorkspaceIsolationV1TestSuite) TestScenario(t provider.T) {
+	suite.StartScenario(t,
+		sdkconsts.AuthorizationProviderV1Name,
+		sdkconsts.WorkspaceProviderV1Name,
+		sdkconsts.StorageProviderV1Name,
+		sdkconsts.ComputeProviderV1Name,
+		sdkconsts.NetworkProviderV1Name,
+	)
+	suite.ConfigureResources(t,
+		string(schema.GlobalTenantResourceMetadataKindResourceKindRole),
+		string(schema.GlobalTenantResourceMetadataKindResourceKindRoleAssignment),
+		string(schema.RegionalResourceMetadataKindResourceKindWorkspace),
+		string(schema.RegionalResourceMetadataKindResourceKindBlockStorage),
+		string(schema.RegionalResourceMetadataKindResourceKindInstance),
+		string(schema.RegionalResourceMetadataKindResourceKindNetwork),
+		string(schema.RegionalResourceMetadataKindResourceKindInternetGateway),
+		string(schema.RegionalResourceMetadataKindResourceKindNic),
+		string(schema.RegionalResourceMetadataKindResourceKindPublicIP),
+		string(schema.RegionalNetworkResourceMetadataKindResourceKindRoutingTable),
+		string(schema.RegionalNetworkResourceMetadataKindResourceKindSubnet),
+		string(schema.RegionalWorkspaceResourceMetadataKindResourceKindSecurityGroup),
+	)
+
+	stepsBuilder := steps.NewStepsConfigurator(suite.TestSuite, t)
+
+	// Authorization - one grant, scoped to both workspaces
+
+	role := suite.params.Role
+	expectRoleMeta := role.Metadata
+	expectRoleSpec := &role.Spec
+	stepsBuilder.CreateOrUpdateRoleV1Step("Create a role", t, suite.GlobalClient.AuthorizationV1, role,
+		steps.ResponseExpects[schema.GlobalTenantResourceMetadata, schema.RoleSpec]{
+			Metadata:       expectRoleMeta,
+			Spec:           expectRoleSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	role = stepsBuilder.GetRoleV1Step("Get the created role", suite.GlobalClient.AuthorizationV1,
+		secapi.TenantReference{Tenant: secapi.TenantID(suite.Tenant), Name: role.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.GlobalTenantResourceMetadata, schema.RoleSpec, schema.RoleStatus]{
+			Metadata: expectRoleMeta,
+			Spec:     expectRoleSpec,
+			ResourceStatus: schema.RoleStatus{
+				State: schema.ResourceStateActive,
+			},
+		},
+	)
+
+	roleAssign := suite.params.RoleAssignment
+	expectRoleAssignMeta := roleAssign.Metadata
+	expectRoleAssignSpec := &roleAssign.Spec
+	stepsBuilder.CreateOrUpdateRoleAssignmentV1Step("Create a role assignment scoped to both workspaces", t, suite.GlobalClient.AuthorizationV1, roleAssign,
+		steps.ResponseExpects[schema.GlobalTenantResourceMetadata, schema.RoleAssignmentSpec]{
+			Metadata:       expectRoleAssignMeta,
+			Spec:           expectRoleAssignSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	roleAssign = stepsBuilder.GetRoleAssignmentV1Step("Get the created role assignment", suite.GlobalClient.AuthorizationV1,
+		secapi.TenantReference{Tenant: secapi.TenantID(suite.Tenant), Name: roleAssign.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.GlobalTenantResourceMetadata, schema.RoleAssignmentSpec, schema.RoleAssignmentStatus]{
+			Metadata: expectRoleAssignMeta,
+			Spec:     expectRoleAssignSpec,
+			ResourceStatus: schema.RoleAssignmentStatus{
+				State: schema.ResourceStateActive,
+			},
+		},
+	)
+
+	// Two fully independent workspace stacks, provisioned under the same shared grant
+
+	workspaceA := suite.params.WorkspaceA
+	workspaceB := suite.params.WorkspaceB
+	stackA := suite.params.StackA
+	stackB := suite.params.StackB
+
+	instanceA := suite.createStack(t, stepsBuilder, "A", workspaceA, stackA)
+	instanceB := suite.createStack(t, stepsBuilder, "B", workspaceB, stackB)
+	stackA.Instance = instanceA
+	stackB.Instance = instanceB
+
+	// Isolation check: listing instances scoped to workspace A must return only
+	// workspace A's instance, never workspace B's (and vice versa).
+	wpathA := secapi.WorkspacePath{Tenant: secapi.TenantID(workspaceA.Metadata.Tenant), Workspace: secapi.WorkspaceID(workspaceA.Metadata.Name)}
+	stepsBuilder.ListInstanceV1Step("List instances in workspace A - expect only workspace A's instance", suite.RegionalClient.ComputeV1, wpathA, nil,
+		steps.ListResponseExpects[schema.Instance]{
+			Metadata: &stackA.Instances.Metadata,
+			Items:    []schema.Instance{*instanceA},
+		},
+	)
+
+	wpathB := secapi.WorkspacePath{Tenant: secapi.TenantID(workspaceB.Metadata.Tenant), Workspace: secapi.WorkspaceID(workspaceB.Metadata.Name)}
+	stepsBuilder.ListInstanceV1Step("List instances in workspace B - expect only workspace B's instance", suite.RegionalClient.ComputeV1, wpathB, nil,
+		steps.ListResponseExpects[schema.Instance]{
+			Metadata: &stackB.Instances.Metadata,
+			Items:    []schema.Instance{*instanceB},
+		},
+	)
+
+	// Resources deletion - each stack torn down independently, then the shared RBAC grant
+
+	suite.deleteStack(t, stepsBuilder, "A", workspaceA, stackA)
+	suite.deleteStack(t, stepsBuilder, "B", workspaceB, stackB)
+
+	stepsBuilder.DeleteRoleAssignmentV1Step("Delete the role assignment", t, suite.GlobalClient.AuthorizationV1, roleAssign)
+	stepsBuilder.DeleteRoleV1Step("Delete the role", t, suite.GlobalClient.AuthorizationV1, role)
+
+	suite.FinishScenario()
+}
+
+func (suite *MultiWorkspaceIsolationV1TestSuite) AfterAll(t provider.T) {
+	suite.ResetAllScenarios()
+}

--- a/internal/conformance/suites/usage/private_secure_workspace_v1.go
+++ b/internal/conformance/suites/usage/private_secure_workspace_v1.go
@@ -1,0 +1,479 @@
+package usage
+
+import (
+	"log/slog"
+	"math/rand"
+
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/params"
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/steps"
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/suites"
+	"github.com/eu-sovereign-cloud/conformance/internal/constants"
+	mockUsage "github.com/eu-sovereign-cloud/conformance/internal/mock/scenarios/usage"
+	"github.com/eu-sovereign-cloud/conformance/pkg/builders"
+	"github.com/eu-sovereign-cloud/conformance/pkg/generators"
+	sdkconsts "github.com/eu-sovereign-cloud/go-sdk/pkg/constants"
+	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
+	"github.com/eu-sovereign-cloud/go-sdk/secapi"
+
+	"github.com/ozontech/allure-go/pkg/framework/provider"
+)
+
+// PrivateSecureWorkspaceV1TestSuite provisions a fully isolated instance: a network
+// routed only through an egress-only internet gateway (no inbound path from the
+// internet), a restrictive security group, and a nic with no public IP attached at
+// all. Unlike the other usage scenarios, no PublicIp resource is ever created here -
+// that absence is the point of the scenario.
+type PrivateSecureWorkspaceV1TestSuite struct {
+	suites.RegionalTestSuite
+
+	config *PrivateSecureWorkspaceV1Config
+	params *params.PrivateSecureWorkspaceV1Params
+}
+
+type PrivateSecureWorkspaceV1Config struct {
+	NetworkCidr  string
+	RegionZones  []string
+	StorageSkus  []string
+	InstanceSkus []string
+	NetworkSkus  []string
+}
+
+func CreatePrivateSecureWorkspaceV1TestSuite(regionalTestSuite suites.RegionalTestSuite, config *PrivateSecureWorkspaceV1Config) *PrivateSecureWorkspaceV1TestSuite {
+	suite := &PrivateSecureWorkspaceV1TestSuite{
+		RegionalTestSuite: regionalTestSuite,
+		config:            config,
+	}
+	suite.ScenarioName = constants.UsagePrivateSecureWorkspaceV1SuiteName.String()
+	return suite
+}
+
+func (suite *PrivateSecureWorkspaceV1TestSuite) BeforeAll(t provider.T) {
+	t.AddParentSuite(suites.UsageParentSuite)
+
+	subnetCidr, err := generators.GenerateSubnetCidr(suite.config.NetworkCidr, 8, 1)
+	if err != nil {
+		slog.Error("Failed to generate subnet cidr", "error", err)
+		t.FailNow()
+	}
+	nicAddress, err := generators.GenerateNicAddress(subnetCidr, 1)
+	if err != nil {
+		slog.Error("Failed to generate nic address", "error", err)
+		t.FailNow()
+	}
+
+	zone := suite.config.RegionZones[rand.Intn(len(suite.config.RegionZones))]
+	storageSkuName := suite.config.StorageSkus[rand.Intn(len(suite.config.StorageSkus))]
+	instanceSkuName := suite.config.InstanceSkus[rand.Intn(len(suite.config.InstanceSkus))]
+	networkSkuName := suite.config.NetworkSkus[rand.Intn(len(suite.config.NetworkSkus))]
+
+	workspaceName := generators.GenerateWorkspaceName()
+
+	storageSkuRefObj := generators.GenerateSkuRefObject(sdkconsts.StorageProviderV1Name, suite.Tenant, storageSkuName)
+	instanceSkuRefObj := generators.GenerateSkuRefObject(sdkconsts.ComputeProviderV1Name, suite.Tenant, instanceSkuName)
+	networkSkuRefObj := generators.GenerateSkuRefObject(sdkconsts.NetworkProviderV1Name, suite.Tenant, networkSkuName)
+
+	blockStorageName := generators.GenerateBlockStorageName()
+	blockStorageRefObj := generators.GenerateBlockStorageRefObject(sdkconsts.StorageProviderV1Name, suite.Tenant, workspaceName, blockStorageName)
+
+	networkName := generators.GenerateNetworkName()
+
+	internetGatewayName := generators.GenerateInternetGatewayName()
+	internetGatewayRefObj := generators.GenerateInternetGatewayRefObject(sdkconsts.NetworkProviderV1Name, suite.Tenant, workspaceName, internetGatewayName)
+
+	routeTableName := generators.GenerateRouteTableName()
+	routeTableRefObj := generators.GenerateRouteTableRefObject(sdkconsts.NetworkProviderV1Name, suite.Tenant, workspaceName, networkName, routeTableName)
+
+	subnetName := generators.GenerateSubnetName()
+	subnetRefObj := generators.GenerateSubnetRefObject(sdkconsts.NetworkProviderV1Name, suite.Tenant, workspaceName, networkName, subnetName)
+
+	securityGroupName := generators.GenerateSecurityGroupName()
+
+	nicName := generators.GenerateNicName()
+
+	instanceName := generators.GenerateInstanceName()
+
+	workspace, err := builders.NewWorkspaceBuilder().
+		Name(workspaceName).
+		Provider(sdkconsts.WorkspaceProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Region(suite.Region).
+		Labels(schema.Labels{
+			constants.EnvLabel: constants.EnvConformanceLabel,
+		}).
+		Annotations(schema.Annotations{
+			"description": "Fully isolated workspace with no internet ingress",
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build Workspace: %v", err)
+	}
+
+	blockStorage, err := builders.NewBlockStorageBuilder().
+		Name(blockStorageName).
+		Provider(sdkconsts.StorageProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.BlockStorageSpec{
+			SkuRef: *storageSkuRefObj,
+			SizeGB: constants.BlockStorageInitialSize,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build BlockStorage: %v", err)
+	}
+
+	network, err := builders.NewNetworkBuilder().
+		Name(networkName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.NetworkSpec{
+			Cidr:   schema.Cidr{Ipv4: suite.config.NetworkCidr},
+			SkuRef: *networkSkuRefObj,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Network: %v", err)
+	}
+
+	// Egress-only: outbound traffic is allowed, nothing can be initiated from the internet
+	internetGateway, err := builders.NewInternetGatewayBuilder().
+		Name(internetGatewayName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.InternetGatewaySpec{
+			EgressOnly: true,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Internet Gateway: %v", err)
+	}
+
+	routeTable, err := builders.NewRouteTableBuilder().
+		Name(routeTableName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).Network(networkName).
+		Spec(&schema.RouteTableSpec{
+			Routes: []schema.RouteSpec{
+				{DestinationCidrBlock: constants.RouteTableDefaultDestination, TargetRef: *internetGatewayRefObj},
+			},
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Route Table: %v", err)
+	}
+
+	subnet, err := builders.NewSubnetBuilder().
+		Name(subnetName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).Network(networkName).
+		Spec(&schema.SubnetSpec{
+			Cidr:          schema.Cidr{Ipv4: subnetCidr},
+			RouteTableRef: *routeTableRefObj,
+			Zone:          zone,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Subnet: %v", err)
+	}
+
+	// Restrictive baseline: explicit ingress and egress entries, no open ingress rule
+	securityGroup, err := builders.NewSecurityGroupBuilder().
+		Name(securityGroupName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.SecurityGroupSpec{
+			Rules: []schema.SecurityGroupRuleSpec{
+				{Direction: schema.SecurityGroupRuleDirectionIngress},
+				{Direction: schema.SecurityGroupRuleDirectionEgress},
+			},
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Security Group: %v", err)
+	}
+
+	// No PublicIpRefs - this nic is only reachable from inside the network
+	nic, err := builders.NewNicBuilder().
+		Name(nicName).
+		Provider(sdkconsts.NetworkProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.NicSpec{
+			Addresses: []string{nicAddress},
+			SubnetRef: *subnetRefObj,
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Nic: %v", err)
+	}
+
+	instance, err := builders.NewInstanceBuilder().
+		Name(instanceName).
+		Provider(sdkconsts.ComputeProviderV1Name).ApiVersion(sdkconsts.ApiVersion1).
+		Tenant(suite.Tenant).Workspace(workspaceName).Region(suite.Region).
+		Spec(&schema.InstanceSpec{
+			SkuRef: *instanceSkuRefObj,
+			Zone:   zone,
+			BootVolume: schema.VolumeReference{
+				DeviceRef: *blockStorageRefObj,
+			},
+		}).Build()
+	if err != nil {
+		t.Fatalf("Failed to build Instance: %v", err)
+	}
+
+	p := &params.PrivateSecureWorkspaceV1Params{
+		Workspace:       workspace,
+		BlockStorage:    blockStorage,
+		Network:         network,
+		InternetGateway: internetGateway,
+		RouteTable:      routeTable,
+		Subnet:          subnet,
+		SecurityGroup:   securityGroup,
+		Nic:             nic,
+		Instance:        instance,
+	}
+	suite.params = p
+	err = suites.SetupMockIfEnabled(suite.TestSuite, mockUsage.ConfigurePrivateSecureWorkspaceV1, *p)
+	if err != nil {
+		t.Fatalf("Failed to setup mock: %v", err)
+	}
+}
+
+func (suite *PrivateSecureWorkspaceV1TestSuite) TestScenario(t provider.T) {
+	suite.StartScenario(t,
+		sdkconsts.WorkspaceProviderV1Name,
+		sdkconsts.StorageProviderV1Name,
+		sdkconsts.ComputeProviderV1Name,
+		sdkconsts.NetworkProviderV1Name,
+	)
+	suite.ConfigureResources(t,
+		string(schema.RegionalResourceMetadataKindResourceKindWorkspace),
+		string(schema.RegionalResourceMetadataKindResourceKindBlockStorage),
+		string(schema.RegionalResourceMetadataKindResourceKindInstance),
+		string(schema.RegionalResourceMetadataKindResourceKindNetwork),
+		string(schema.RegionalResourceMetadataKindResourceKindInternetGateway),
+		string(schema.RegionalResourceMetadataKindResourceKindNic),
+		string(schema.RegionalNetworkResourceMetadataKindResourceKindRoutingTable),
+		string(schema.RegionalNetworkResourceMetadataKindResourceKindSubnet),
+		string(schema.RegionalWorkspaceResourceMetadataKindResourceKindSecurityGroup),
+	)
+
+	stepsBuilder := steps.NewStepsConfigurator(suite.TestSuite, t)
+
+	workspace := suite.params.Workspace
+	expectWorkspaceMeta := workspace.Metadata
+	expectWorkspaceLabels := workspace.Labels
+	expectWorkspaceAnnotations := workspace.Annotations
+	stepsBuilder.CreateOrUpdateWorkspaceV1Step("Create a workspace", t, suite.Client.WorkspaceV1, workspace,
+		steps.ResponseExpects[schema.RegionalResourceMetadata, schema.WorkspaceSpec]{
+			Labels:         expectWorkspaceLabels,
+			Annotations:    expectWorkspaceAnnotations,
+			Metadata:       expectWorkspaceMeta,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetWorkspaceV1Step("Get the created workspace", suite.Client.WorkspaceV1,
+		secapi.TenantReference{Tenant: secapi.TenantID(workspace.Metadata.Tenant), Name: workspace.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalResourceMetadata, schema.WorkspaceSpec, schema.WorkspaceStatus]{
+			Labels:   expectWorkspaceLabels,
+			Metadata: expectWorkspaceMeta,
+			ResourceStatus: schema.WorkspaceStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	block := suite.params.BlockStorage
+	expectBlockMeta := block.Metadata
+	expectBlockSpec := &block.Spec
+	stepsBuilder.CreateOrUpdateBlockStorageV1Step("Create a block storage", t, suite.Client.StorageV1, block,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.BlockStorageSpec]{
+			Metadata:       expectBlockMeta,
+			Spec:           expectBlockSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetBlockStorageV1Step("Get the created block storage", suite.Client.StorageV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(block.Metadata.Tenant), Workspace: secapi.WorkspaceID(block.Metadata.Workspace), Name: block.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.BlockStorageSpec, schema.BlockStorageStatus]{
+			Metadata: expectBlockMeta,
+			Spec:     expectBlockSpec,
+			ResourceStatus: schema.BlockStorageStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	network := suite.params.Network
+	expectNetworkMeta := network.Metadata
+	expectNetworkSpec := &network.Spec
+	stepsBuilder.CreateOrUpdateNetworkV1Step("Create a network", t, suite.Client.NetworkV1, network,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.NetworkSpec]{
+			Metadata:       expectNetworkMeta,
+			Spec:           expectNetworkSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+
+	// The response spec comparison here round-trips EgressOnly: true, proving the
+	// provider accepts and persists an internet gateway with no inbound path.
+	gateway := suite.params.InternetGateway
+	expectGatewayMeta := gateway.Metadata
+	expectGatewaySpec := &gateway.Spec
+	stepsBuilder.CreateOrUpdateInternetGatewayV1Step("Create an egress-only internet gateway", t, suite.Client.NetworkV1, gateway,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.InternetGatewaySpec]{
+			Metadata:       expectGatewayMeta,
+			Spec:           expectGatewaySpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetInternetGatewayV1Step("Get the created internet gateway", suite.Client.NetworkV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(gateway.Metadata.Tenant), Workspace: secapi.WorkspaceID(gateway.Metadata.Workspace), Name: gateway.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.InternetGatewaySpec, schema.InternetGatewayStatus]{
+			Metadata: expectGatewayMeta,
+			Spec:     expectGatewaySpec,
+			ResourceStatus: schema.InternetGatewayStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	route := suite.params.RouteTable
+	expectRouteMeta := route.Metadata
+	expectRouteSpec := &route.Spec
+	stepsBuilder.CreateOrUpdateRouteTableV1Step("Create a route table", t, suite.Client.NetworkV1, route,
+		steps.ResponseExpects[schema.RegionalNetworkResourceMetadata, schema.RouteTableSpec]{
+			Metadata:       expectRouteMeta,
+			Spec:           expectRouteSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetRouteTableV1Step("Get the created route table", suite.Client.NetworkV1,
+		secapi.NetworkReference{Tenant: secapi.TenantID(route.Metadata.Tenant), Workspace: secapi.WorkspaceID(route.Metadata.Workspace), Network: secapi.NetworkID(route.Metadata.Network), Name: route.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalNetworkResourceMetadata, schema.RouteTableSpec, schema.RouteTableStatus]{
+			Metadata: expectRouteMeta,
+			Spec:     expectRouteSpec,
+			ResourceStatus: schema.RouteTableStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	stepsBuilder.GetNetworkV1Step("Get the created network", suite.Client.NetworkV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(network.Metadata.Tenant), Workspace: secapi.WorkspaceID(network.Metadata.Workspace), Name: network.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.NetworkSpec, schema.NetworkStatus]{
+			Metadata: expectNetworkMeta,
+			Spec:     expectNetworkSpec,
+			ResourceStatus: schema.NetworkStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	subnet := suite.params.Subnet
+	expectSubnetMeta := subnet.Metadata
+	expectSubnetSpec := &subnet.Spec
+	stepsBuilder.CreateOrUpdateSubnetV1Step("Create a subnet", t, suite.Client.NetworkV1, subnet,
+		steps.ResponseExpects[schema.RegionalNetworkResourceMetadata, schema.SubnetSpec]{
+			Metadata:       expectSubnetMeta,
+			Spec:           expectSubnetSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetSubnetV1Step("Get the created subnet", suite.Client.NetworkV1,
+		secapi.NetworkReference{Tenant: secapi.TenantID(subnet.Metadata.Tenant), Workspace: secapi.WorkspaceID(subnet.Metadata.Workspace), Network: secapi.NetworkID(subnet.Metadata.Network), Name: subnet.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalNetworkResourceMetadata, schema.SubnetSpec, schema.SubnetStatus]{
+			Metadata: expectSubnetMeta,
+			Spec:     expectSubnetSpec,
+			ResourceStatus: schema.SubnetStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	group := suite.params.SecurityGroup
+	expectGroupMeta := group.Metadata
+	expectGroupSpec := &group.Spec
+	stepsBuilder.CreateOrUpdateSecurityGroupV1Step("Create a restrictive security group", t, suite.Client.NetworkV1, group,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.SecurityGroupSpec]{
+			Metadata:       expectGroupMeta,
+			Spec:           expectGroupSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetSecurityGroupV1Step("Get the created security group", suite.Client.NetworkV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(group.Metadata.Tenant), Workspace: secapi.WorkspaceID(group.Metadata.Workspace), Name: group.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.SecurityGroupSpec, schema.SecurityGroupStatus]{
+			Metadata: expectGroupMeta,
+			Spec:     expectGroupSpec,
+			ResourceStatus: schema.SecurityGroupStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	// No PublicIp resource is ever created in this scenario - the nic's spec
+	// comparison below proves PublicIpRefs comes back empty.
+	nic := suite.params.Nic
+	expectNicMeta := nic.Metadata
+	expectNicSpec := &nic.Spec
+	stepsBuilder.CreateOrUpdateNicV1Step("Create a private nic", t, suite.Client.NetworkV1, nic,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.NicSpec]{
+			Metadata:       expectNicMeta,
+			Spec:           expectNicSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	stepsBuilder.GetNicV1Step("Get the created private nic", suite.Client.NetworkV1,
+		secapi.WorkspaceReference{Tenant: secapi.TenantID(nic.Metadata.Tenant), Workspace: secapi.WorkspaceID(nic.Metadata.Workspace), Name: nic.Metadata.Name},
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.NicSpec, schema.NicStatus]{
+			Metadata: expectNicMeta,
+			Spec:     expectNicSpec,
+			ResourceStatus: schema.NicStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	instance := suite.params.Instance
+	expectInstanceMeta := instance.Metadata
+	expectInstanceSpec := &instance.Spec
+	stepsBuilder.CreateOrUpdateInstanceV1Step("Create the private instance", t, suite.Client.ComputeV1, instance,
+		steps.ResponseExpects[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec]{
+			Metadata:       expectInstanceMeta,
+			Spec:           expectInstanceSpec,
+			ResourceStates: suites.CreatedResourceExpectedStates,
+		},
+	)
+	instanceWRef := secapi.WorkspaceReference{
+		Tenant:    secapi.TenantID(instance.Metadata.Tenant),
+		Workspace: secapi.WorkspaceID(instance.Metadata.Workspace),
+		Name:      instance.Metadata.Name,
+	}
+	instance = stepsBuilder.GetInstanceV1Step("Get the created private instance", suite.Client.ComputeV1, instanceWRef,
+		steps.ResponseExpectsWithCondition[schema.RegionalWorkspaceResourceMetadata, schema.InstanceSpec, schema.InstanceStatus]{
+			Metadata: expectInstanceMeta,
+			Spec:     expectInstanceSpec,
+			ResourceStatus: schema.InstanceStatus{
+				State:      schema.ResourceStateActive,
+				Conditions: suites.GetConditionAfterCreating,
+			},
+		},
+	)
+
+	// Resources deletion - reverse dependency order
+	stepsBuilder.DeleteInstanceV1Step("Delete the private instance", t, suite.Client.ComputeV1, instance)
+	stepsBuilder.DeleteNicV1Step("Delete the private nic", t, suite.Client.NetworkV1, nic)
+	stepsBuilder.DeleteSecurityGroupV1Step("Delete the security group", t, suite.Client.NetworkV1, group)
+	stepsBuilder.DeleteSubnetV1Step("Delete the subnet", t, suite.Client.NetworkV1, subnet)
+	stepsBuilder.DeleteRouteTableV1Step("Delete the route table", t, suite.Client.NetworkV1, route)
+	stepsBuilder.DeleteInternetGatewayV1Step("Delete the internet gateway", t, suite.Client.NetworkV1, gateway)
+	stepsBuilder.DeleteNetworkV1Step("Delete the network", t, suite.Client.NetworkV1, network)
+	stepsBuilder.DeleteBlockStorageV1Step("Delete the block storage", t, suite.Client.StorageV1, block)
+	stepsBuilder.DeleteWorkspaceV1Step("Delete the workspace", t, suite.Client.WorkspaceV1, workspace)
+
+	suite.FinishScenario()
+}
+
+func (suite *PrivateSecureWorkspaceV1TestSuite) AfterAll(t provider.T) {
+	suite.ResetAllScenarios()
+}

--- a/internal/constants/suites_v1.go
+++ b/internal/constants/suites_v1.go
@@ -38,7 +38,11 @@ const (
 	NicLifeCycleV1SuiteName               SuiteName = "Network.V1.NicLifeCycle"
 	RouteTableLifeCycleV1SuiteName        SuiteName = "Network.V1.RouteTableLifeCycle"
 
-	UsageFoundationProvidersV1SuiteName SuiteName = "Usage.V1.FoundationProviders"
+	UsageFoundationProvidersV1SuiteName     SuiteName = "Usage.V1.FoundationProviders"
+	UsageMultiTierWorkloadV1SuiteName       SuiteName = "Usage.V1.MultiTierWorkload"
+	UsageMultiWorkspaceIsolationV1SuiteName SuiteName = "Usage.V1.MultiWorkspaceIsolation"
+	UsageHaMultiZoneV1SuiteName             SuiteName = "Usage.V1.HaMultiZone"
+	UsagePrivateSecureWorkspaceV1SuiteName  SuiteName = "Usage.V1.PrivateSecureWorkspace"
 
 	RoleAssignmentErrorV1SuiteName    SuiteName = "Authorization.V1.RoleAssignmentError"
 	BlockStorageErrorV1SuiteName      SuiteName = "Storage.V1.BlockStorageError"
@@ -128,6 +132,10 @@ var AllSuiteNames = []SuiteName{
 	RouteTableErrorV1SuiteName,
 
 	UsageFoundationProvidersV1SuiteName,
+	UsageMultiTierWorkloadV1SuiteName,
+	UsageMultiWorkspaceIsolationV1SuiteName,
+	UsageHaMultiZoneV1SuiteName,
+	UsagePrivateSecureWorkspaceV1SuiteName,
 	RoleAssignmentErrorV1SuiteName,
 	RoleErrorV1SuiteName,
 	BlockStorageErrorV1SuiteName,

--- a/internal/mock/scenarios/usage/ha_multi_zone_v1.go
+++ b/internal/mock/scenarios/usage/ha_multi_zone_v1.go
@@ -1,0 +1,115 @@
+package mockusage
+
+import (
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/params"
+	mockscenarios "github.com/eu-sovereign-cloud/conformance/internal/mock/scenarios"
+	"github.com/eu-sovereign-cloud/conformance/pkg/generators"
+	sdkconsts "github.com/eu-sovereign-cloud/go-sdk/pkg/constants"
+)
+
+func ConfigureHaMultiZoneV1(scenario *mockscenarios.Scenario, p params.HaMultiZoneV1Params) error {
+	configurator, err := scenario.StartConfiguration()
+	if err != nil {
+		return err
+	}
+
+	workspace := p.Workspace
+	blockA := p.BlockStorageA
+	blockB := p.BlockStorageB
+	replicaA := p.ReplicaA
+	replicaB := p.ReplicaB
+
+	workspaceUrl := generators.GenerateWorkspaceURL(sdkconsts.WorkspaceProviderV1Name, workspace.Metadata.Tenant, workspace.Metadata.Name)
+	blockAUrl := generators.GenerateBlockStorageURL(sdkconsts.StorageProviderV1Name, blockA.Metadata.Tenant, blockA.Metadata.Workspace, blockA.Metadata.Name)
+	blockBUrl := generators.GenerateBlockStorageURL(sdkconsts.StorageProviderV1Name, blockB.Metadata.Tenant, blockB.Metadata.Workspace, blockB.Metadata.Name)
+	replicaAUrl := generators.GenerateInstanceURL(sdkconsts.ComputeProviderV1Name, replicaA.Metadata.Tenant, replicaA.Metadata.Workspace, replicaA.Metadata.Name)
+	replicaAStartUrl := generators.GenerateInstanceStartURL(sdkconsts.ComputeProviderV1Name, replicaA.Metadata.Tenant, replicaA.Metadata.Workspace, replicaA.Metadata.Name)
+	replicaBUrl := generators.GenerateInstanceURL(sdkconsts.ComputeProviderV1Name, replicaB.Metadata.Tenant, replicaB.Metadata.Workspace, replicaB.Metadata.Name)
+	replicaBStartUrl := generators.GenerateInstanceStartURL(sdkconsts.ComputeProviderV1Name, replicaB.Metadata.Tenant, replicaB.Metadata.Workspace, replicaB.Metadata.Name)
+
+	if err := configurator.ConfigureCreateWorkspaceStub(workspace, workspaceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingWorkspaceStub(workspace, workspaceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveWorkspaceStub(workspace, workspaceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateBlockStorageStub(blockA, blockAUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingBlockStorageStub(blockA, blockAUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveBlockStorageStub(blockA, blockAUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateBlockStorageStub(blockB, blockBUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingBlockStorageStub(blockB, blockBUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveBlockStorageStub(blockB, blockBUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateInstanceStub(replicaA, replicaAUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingInstanceStub(replicaA, replicaAUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveInstanceStub(replicaA, replicaAUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateInstanceStub(replicaB, replicaBUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingInstanceStub(replicaB, replicaBUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveInstanceStub(replicaB, replicaBUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	// Start both replicas
+	if err := configurator.ConfigureInstanceOperationStub(replicaA, replicaAStartUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveInstanceStub(replicaA, replicaAUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureInstanceOperationStub(replicaB, replicaBStartUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveInstanceStub(replicaB, replicaBUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	// Delete all
+	if err := configurator.ConfigureDeleteStub(replicaAUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(replicaBUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(blockAUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(blockBUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(workspaceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := scenario.FinishConfiguration(configurator); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/mock/scenarios/usage/multi_workspace_isolation_v1.go
+++ b/internal/mock/scenarios/usage/multi_workspace_isolation_v1.go
@@ -1,0 +1,256 @@
+package mockusage
+
+import (
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/params"
+	"github.com/eu-sovereign-cloud/conformance/internal/mock"
+	mockscenarios "github.com/eu-sovereign-cloud/conformance/internal/mock/scenarios"
+	"github.com/eu-sovereign-cloud/conformance/internal/mock/stubs"
+	"github.com/eu-sovereign-cloud/conformance/pkg/generators"
+	sdkconsts "github.com/eu-sovereign-cloud/go-sdk/pkg/constants"
+	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
+)
+
+// workspaceStackURLs holds every URL used across the create, list and delete phases
+// of a stack, so they only need to be derived once per stack.
+type workspaceStackURLs struct {
+	workspace, block, network, gateway, route, subnet, group, publicIp, nic, instance, instanceList string
+}
+
+func newWorkspaceStackURLs(workspace *schema.Workspace, stack params.WorkspaceStackV1) workspaceStackURLs {
+	return workspaceStackURLs{
+		workspace:    generators.GenerateWorkspaceURL(sdkconsts.WorkspaceProviderV1Name, workspace.Metadata.Tenant, workspace.Metadata.Name),
+		block:        generators.GenerateBlockStorageURL(sdkconsts.StorageProviderV1Name, stack.BlockStorage.Metadata.Tenant, stack.BlockStorage.Metadata.Workspace, stack.BlockStorage.Metadata.Name),
+		network:      generators.GenerateNetworkURL(sdkconsts.NetworkProviderV1Name, stack.Network.Metadata.Tenant, stack.Network.Metadata.Workspace, stack.Network.Metadata.Name),
+		gateway:      generators.GenerateInternetGatewayURL(sdkconsts.NetworkProviderV1Name, stack.InternetGateway.Metadata.Tenant, stack.InternetGateway.Metadata.Workspace, stack.InternetGateway.Metadata.Name),
+		route:        generators.GenerateRouteTableURL(sdkconsts.NetworkProviderV1Name, stack.RouteTable.Metadata.Tenant, stack.RouteTable.Metadata.Workspace, stack.RouteTable.Metadata.Network, stack.RouteTable.Metadata.Name),
+		subnet:       generators.GenerateSubnetURL(sdkconsts.NetworkProviderV1Name, stack.Subnet.Metadata.Tenant, stack.Subnet.Metadata.Workspace, stack.Subnet.Metadata.Network, stack.Subnet.Metadata.Name),
+		group:        generators.GenerateSecurityGroupURL(sdkconsts.NetworkProviderV1Name, stack.SecurityGroup.Metadata.Tenant, stack.SecurityGroup.Metadata.Workspace, stack.SecurityGroup.Metadata.Name),
+		publicIp:     generators.GeneratePublicIpURL(sdkconsts.NetworkProviderV1Name, stack.PublicIp.Metadata.Tenant, stack.PublicIp.Metadata.Workspace, stack.PublicIp.Metadata.Name),
+		nic:          generators.GenerateNicURL(sdkconsts.NetworkProviderV1Name, stack.Nic.Metadata.Tenant, stack.Nic.Metadata.Workspace, stack.Nic.Metadata.Name),
+		instance:     generators.GenerateInstanceURL(sdkconsts.ComputeProviderV1Name, stack.Instance.Metadata.Tenant, stack.Instance.Metadata.Workspace, stack.Instance.Metadata.Name),
+		instanceList: generators.GenerateInstanceListURL(sdkconsts.ComputeProviderV1Name, workspace.Metadata.Tenant, workspace.Metadata.Name),
+	}
+}
+
+// configureWorkspaceStackCreateV1, configureWorkspaceStackListV1 and
+// configureWorkspaceStackDeleteV1 are split into three phases - rather than one
+// combined per-stack function - because WireMock scenario state is a single
+// sequential chain per suite. The runtime call order in TestScenario is
+// create(A), create(B), list(A), list(B), delete(A), delete(B), so the mock
+// registration order must follow that same interleaving across both stacks, not
+// register one stack's full create+list+delete sequence before starting the next.
+
+func configureWorkspaceStackCreateV1(configurator *stubs.Configurator, mockParams mock.MockParams, urls workspaceStackURLs, workspace *schema.Workspace, stack params.WorkspaceStackV1) error {
+	if err := configurator.ConfigureCreateWorkspaceStub(workspace, urls.workspace, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingWorkspaceStub(workspace, urls.workspace, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveWorkspaceStub(workspace, urls.workspace, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateBlockStorageStub(stack.BlockStorage, urls.block, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingBlockStorageStub(stack.BlockStorage, urls.block, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveBlockStorageStub(stack.BlockStorage, urls.block, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateNetworkStub(stack.Network, urls.network, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateInternetGatewayStub(stack.InternetGateway, urls.gateway, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingInternetGatewayStub(stack.InternetGateway, urls.gateway, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveInternetGatewayStub(stack.InternetGateway, urls.gateway, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateRouteTableStub(stack.RouteTable, urls.route, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingRouteTableStub(stack.RouteTable, urls.route, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveRouteTableStub(stack.RouteTable, urls.route, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureGetCreatingNetworkStub(stack.Network, urls.network, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveNetworkStub(stack.Network, urls.network, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateSubnetStub(stack.Subnet, urls.subnet, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingSubnetStub(stack.Subnet, urls.subnet, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveSubnetStub(stack.Subnet, urls.subnet, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateSecurityGroupStub(stack.SecurityGroup, urls.group, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingSecurityGroupStub(stack.SecurityGroup, urls.group, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveSecurityGroupStub(stack.SecurityGroup, urls.group, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreatePublicIpStub(stack.PublicIp, urls.publicIp, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingPublicIpStub(stack.PublicIp, urls.publicIp, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActivePublicIpStub(stack.PublicIp, urls.publicIp, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateNicStub(stack.Nic, urls.nic, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingNicStub(stack.Nic, urls.nic, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveNicStub(stack.Nic, urls.nic, mockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateInstanceStub(stack.Instance, urls.instance, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingInstanceStub(stack.Instance, urls.instance, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveInstanceStub(stack.Instance, urls.instance, mockParams); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func configureWorkspaceStackListV1(configurator *stubs.Configurator, mockParams mock.MockParams, urls workspaceStackURLs, stack params.WorkspaceStackV1) error {
+	instances := stack.Instances
+	return configurator.ConfigureListInstanceStub(&instances, urls.instanceList, mockParams, nil)
+}
+
+func configureWorkspaceStackDeleteV1(configurator *stubs.Configurator, mockParams mock.MockParams, urls workspaceStackURLs) error {
+	if err := configurator.ConfigureDeleteStub(urls.instance, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(urls.nic, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(urls.publicIp, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(urls.group, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(urls.subnet, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(urls.route, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(urls.gateway, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(urls.network, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(urls.block, mockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(urls.workspace, mockParams); err != nil {
+		return err
+	}
+	return nil
+}
+
+func ConfigureMultiWorkspaceIsolationV1(scenario *mockscenarios.Scenario, p params.MultiWorkspaceIsolationV1Params) error {
+	configurator, err := scenario.StartConfiguration()
+	if err != nil {
+		return err
+	}
+
+	role := p.Role
+	roleAssignment := p.RoleAssignment
+
+	roleUrl := generators.GenerateRoleURL(sdkconsts.AuthorizationProviderV1Name, role.Metadata.Tenant, role.Metadata.Name)
+	roleAssignUrl := generators.GenerateRoleAssignmentURL(sdkconsts.AuthorizationProviderV1Name, roleAssignment.Metadata.Tenant, roleAssignment.Metadata.Name)
+
+	if err := configurator.ConfigureCreateRoleStub(role, roleUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingRoleStub(role, roleUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveRoleStub(role, roleUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateRoleAssignmentStub(roleAssignment, roleAssignUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingRoleAssignmentStub(roleAssignment, roleAssignUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveRoleAssignmentStub(roleAssignment, roleAssignUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	urlsA := newWorkspaceStackURLs(p.WorkspaceA, p.StackA)
+	urlsB := newWorkspaceStackURLs(p.WorkspaceB, p.StackB)
+
+	// Matches TestScenario: createStack(A), createStack(B), List(A), List(B),
+	// deleteStack(A), deleteStack(B)
+	if err := configureWorkspaceStackCreateV1(configurator, scenario.MockParams, urlsA, p.WorkspaceA, p.StackA); err != nil {
+		return err
+	}
+	if err := configureWorkspaceStackCreateV1(configurator, scenario.MockParams, urlsB, p.WorkspaceB, p.StackB); err != nil {
+		return err
+	}
+
+	if err := configureWorkspaceStackListV1(configurator, scenario.MockParams, urlsA, p.StackA); err != nil {
+		return err
+	}
+	if err := configureWorkspaceStackListV1(configurator, scenario.MockParams, urlsB, p.StackB); err != nil {
+		return err
+	}
+
+	if err := configureWorkspaceStackDeleteV1(configurator, scenario.MockParams, urlsA); err != nil {
+		return err
+	}
+	if err := configureWorkspaceStackDeleteV1(configurator, scenario.MockParams, urlsB); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureDeleteStub(roleAssignUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(roleUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := scenario.FinishConfiguration(configurator); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/mock/scenarios/usage/private_secure_workspace_v1.go
+++ b/internal/mock/scenarios/usage/private_secure_workspace_v1.go
@@ -1,0 +1,163 @@
+package mockusage
+
+import (
+	"github.com/eu-sovereign-cloud/conformance/internal/conformance/params"
+	mockscenarios "github.com/eu-sovereign-cloud/conformance/internal/mock/scenarios"
+	"github.com/eu-sovereign-cloud/conformance/pkg/generators"
+	sdkconsts "github.com/eu-sovereign-cloud/go-sdk/pkg/constants"
+)
+
+func ConfigurePrivateSecureWorkspaceV1(scenario *mockscenarios.Scenario, p params.PrivateSecureWorkspaceV1Params) error {
+	configurator, err := scenario.StartConfiguration()
+	if err != nil {
+		return err
+	}
+
+	workspace := p.Workspace
+	blockStorage := p.BlockStorage
+	network := p.Network
+	gateway := p.InternetGateway
+	routeTable := p.RouteTable
+	subnet := p.Subnet
+	securityGroup := p.SecurityGroup
+	nic := p.Nic
+	instance := p.Instance
+
+	workspaceUrl := generators.GenerateWorkspaceURL(sdkconsts.WorkspaceProviderV1Name, workspace.Metadata.Tenant, workspace.Metadata.Name)
+	blockUrl := generators.GenerateBlockStorageURL(sdkconsts.StorageProviderV1Name, blockStorage.Metadata.Tenant, blockStorage.Metadata.Workspace, blockStorage.Metadata.Name)
+	networkUrl := generators.GenerateNetworkURL(sdkconsts.NetworkProviderV1Name, network.Metadata.Tenant, network.Metadata.Workspace, network.Metadata.Name)
+	gatewayUrl := generators.GenerateInternetGatewayURL(sdkconsts.NetworkProviderV1Name, gateway.Metadata.Tenant, gateway.Metadata.Workspace, gateway.Metadata.Name)
+	routeUrl := generators.GenerateRouteTableURL(sdkconsts.NetworkProviderV1Name, routeTable.Metadata.Tenant, routeTable.Metadata.Workspace, routeTable.Metadata.Network, routeTable.Metadata.Name)
+	subnetUrl := generators.GenerateSubnetURL(sdkconsts.NetworkProviderV1Name, subnet.Metadata.Tenant, subnet.Metadata.Workspace, subnet.Metadata.Network, subnet.Metadata.Name)
+	groupUrl := generators.GenerateSecurityGroupURL(sdkconsts.NetworkProviderV1Name, securityGroup.Metadata.Tenant, securityGroup.Metadata.Workspace, securityGroup.Metadata.Name)
+	nicUrl := generators.GenerateNicURL(sdkconsts.NetworkProviderV1Name, nic.Metadata.Tenant, nic.Metadata.Workspace, nic.Metadata.Name)
+	instanceUrl := generators.GenerateInstanceURL(sdkconsts.ComputeProviderV1Name, instance.Metadata.Tenant, instance.Metadata.Workspace, instance.Metadata.Name)
+
+	// Create
+
+	if err := configurator.ConfigureCreateWorkspaceStub(workspace, workspaceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingWorkspaceStub(workspace, workspaceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveWorkspaceStub(workspace, workspaceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateBlockStorageStub(blockStorage, blockUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingBlockStorageStub(blockStorage, blockUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveBlockStorageStub(blockStorage, blockUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateNetworkStub(network, networkUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateInternetGatewayStub(gateway, gatewayUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingInternetGatewayStub(gateway, gatewayUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveInternetGatewayStub(gateway, gatewayUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateRouteTableStub(routeTable, routeUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingRouteTableStub(routeTable, routeUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveRouteTableStub(routeTable, routeUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureGetCreatingNetworkStub(network, networkUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveNetworkStub(network, networkUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateSubnetStub(subnet, subnetUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingSubnetStub(subnet, subnetUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveSubnetStub(subnet, subnetUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateSecurityGroupStub(securityGroup, groupUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingSecurityGroupStub(securityGroup, groupUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveSecurityGroupStub(securityGroup, groupUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateNicStub(nic, nicUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingNicStub(nic, nicUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveNicStub(nic, nicUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := configurator.ConfigureCreateInstanceStub(instance, instanceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetCreatingInstanceStub(instance, instanceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureGetActiveInstanceStub(instance, instanceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	// Delete all
+
+	if err := configurator.ConfigureDeleteStub(instanceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(nicUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(groupUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(subnetUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(routeUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(gatewayUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(networkUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(blockUrl, scenario.MockParams); err != nil {
+		return err
+	}
+	if err := configurator.ConfigureDeleteStub(workspaceUrl, scenario.MockParams); err != nil {
+		return err
+	}
+
+	if err := scenario.FinishConfiguration(configurator); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #45
### Add 3 new usage scenarios: HA Multi-Zone, Multi-Workspace Isolation, Private Secure Workspace
Extends the Usage conformance suite with three complex, multi-resource scenarios that exercise realistic deployment patterns beyond the existing single-stack "foundation providers" scenario.

#### Usage.V1.HaMultiZone
Provisions two instance replicas tagged with the same AntiAffinityGroup but placed in different zones, then starts both concurrently. Verifies the provider accepts and persists zone + anti-affinity placement for a high-availability pair.

#### Usage.V1.MultiWorkspaceIsolation
Provisions two fully independent regional stacks (network, subnet, route table, gateway, security group, public IP, NIC, block storage, instance) in two separate workspaces under the same tenant, governed by a single Role/RoleAssignment scoped to both workspaces. Verifies:

one shared RBAC grant works correctly across multiple workspaces
listing instances per workspace returns only that workspace's own resources (isolation)
#### Usage.V1.PrivateSecureWorkspace
Provisions a fully isolated instance behind an egress-only internet gateway (no inbound path), a restrictive security group with explicit ingress/egress rules, and a NIC with no public IP attached at all. Unlike the other scenarios, no PublicIp resource is ever created — proving the provider supports a network topology with zero internet ingress.

#### Other changes
Registers all three suites in cmd/conformance/usage_test.go, adding a RegionalTestSuite alongside the existing MixedTestSuite (HA Multi-Zone and Private Secure Workspace only need a single region/tenant, not the multi-workspace RBAC setup).
Adds mock scenario configurations under internal/mock/scenarios/usage/ for offline/mock test runs.
Adds corresponding param structs in internal/conformance/params/params_v1.go.

	 